### PR TITLE
Extensible bulletin heading augmentation indicators

### DIFF
--- a/src/main/java/fi/fmi/avi/converter/ConversionHints.java
+++ b/src/main/java/fi/fmi/avi/converter/ConversionHints.java
@@ -241,6 +241,8 @@ public final class ConversionHints implements Map<Object, Object>, Cloneable {
      */
     public static final Object VALUE_TAF_REFERENCE_POLICY_USE_OWN_VALID_TIME_ONLY = "USE_OWN_VALID_TIME_ONLY";
 
+    public static final Key KEY_BULLETIN_HEADING_AUGMENTATION_INDICATOR_EXTENSION;
+
     /**
      * A convenience ParsingHints including only the {@link ConversionHints#KEY_MESSAGE_TYPE} with value {@link MessageType#METAR}.
      */
@@ -308,6 +310,9 @@ public final class ConversionHints implements Map<Object, Object>, Cloneable {
                 VALUE_TAF_REFERENCE_POLICY_USE_REFERRED_REPORT_VALID_TIME_FOR_CNL,//
                 VALUE_TAF_REFERENCE_POLICY_USE_REFERRED_REPORT_VALID_TIME_FOR_COR_CNL,//
                 VALUE_TAF_REFERENCE_POLICY_USE_REFERRED_REPORT_VALID_TIME_FOR_COR_CNL_AMD);
+
+        KEY_BULLETIN_HEADING_AUGMENTATION_INDICATOR_EXTENSION = new KeyImpl(13,
+                "Bulletin heading BBB indicator extension. The value is a function that will " + "be used to convert freeform strings to valid BBB indicators");
 
         METAR = new ConversionHints(KEY_MESSAGE_TYPE, MessageType.METAR);
         TAF = new ConversionHints(KEY_MESSAGE_TYPE, MessageType.TAF);

--- a/src/main/java/fi/fmi/avi/converter/ConversionHints.java
+++ b/src/main/java/fi/fmi/avi/converter/ConversionHints.java
@@ -7,28 +7,29 @@ import java.util.Map;
 import java.util.Set;
 
 import fi.fmi.avi.model.MessageType;
+import fi.fmi.avi.util.BulletinHeadingIndicatorInterpreter;
 
 /**
  * ConversionHints provides lexing, parsing and serializing related
  * implementation hints for aviation weather message processing operations.
- *
+ * <p>
  * Note that since these keys and values are <i>hints</i>, there is
  * no requirement that a given implementation supports all possible
  * choices indicated below or that it can respond to requests to
  * modify its functionality.
- *
+ * <p>
  * Implementations are free to ignore the hints completely, but should
  * try to use an implementation option that is as close as possible
  * to the request.
- *
+ * <p>
  * The keys used to control the hints are all special values that
  * subclass the associated {@link ConversionHints.Key} class.
- *
+ * <p>
  * Many common hints are expressed below as static constants in this
  * class, but the list is not meant to be exhaustive.
  * Other hints may be created by other packages by defining new objects
  * which subclass the {@code Key} class and defining the associated values.
- *
+ * <p>
  * This class is heavily influenced by {@link java.awt.RenderingHints}
  *
  * @author Ilkka Rinne / Spatineo 2017
@@ -214,6 +215,11 @@ public final class ConversionHints implements Map<Object, Object>, Cloneable {
     public static final Object VALUE_BULLETIN_HEADING_SPACING_SPACE = "SPACE";
 
     /**
+     * Extended interpretations for bulletin heading augmentation indicator (BBB). The value has to be of type {@link BulletinHeadingIndicatorInterpreter}.
+     */
+    public static final Key KEY_BULLETIN_HEADING_AUGMENTATION_INDICATOR_EXTENSION;
+
+    /**
      * How the TAC TAF valid time field is matched with TAF POJO validityTime or referredReport/validityTime fields.
      */
     public static final Key KEY_TAF_REFERENCE_POLICY;
@@ -240,8 +246,6 @@ public final class ConversionHints implements Map<Object, Object>, Cloneable {
      * validityTime of the TAF object should always be matched with the valid time of the TAC TAF message regardless of the message type.
      */
     public static final Object VALUE_TAF_REFERENCE_POLICY_USE_OWN_VALID_TIME_ONLY = "USE_OWN_VALID_TIME_ONLY";
-
-    public static final Key KEY_BULLETIN_HEADING_AUGMENTATION_INDICATOR_EXTENSION;
 
     /**
      * A convenience ParsingHints including only the {@link ConversionHints#KEY_MESSAGE_TYPE} with value {@link MessageType#METAR}.
@@ -311,8 +315,17 @@ public final class ConversionHints implements Map<Object, Object>, Cloneable {
                 VALUE_TAF_REFERENCE_POLICY_USE_REFERRED_REPORT_VALID_TIME_FOR_COR_CNL,//
                 VALUE_TAF_REFERENCE_POLICY_USE_REFERRED_REPORT_VALID_TIME_FOR_COR_CNL_AMD);
 
-        KEY_BULLETIN_HEADING_AUGMENTATION_INDICATOR_EXTENSION = new KeyImpl(13,
-                "Bulletin heading BBB indicator extension. The value is a function that will " + "be used to convert freeform strings to valid BBB indicators");
+        KEY_BULLETIN_HEADING_AUGMENTATION_INDICATOR_EXTENSION = new Key(13) {
+            @Override
+            public boolean isCompatibleValue(final Object value) {
+                return value instanceof BulletinHeadingIndicatorInterpreter;
+            }
+
+            @Override
+            public String toString() {
+                return "Bulletin heading BBB indicator extension. The value will be used to convert freeform strings to valid BBB indicators";
+            }
+        };
 
         METAR = new ConversionHints(KEY_MESSAGE_TYPE, MessageType.METAR);
         TAF = new ConversionHints(KEY_MESSAGE_TYPE, MessageType.TAF);
@@ -339,8 +352,7 @@ public final class ConversionHints implements Map<Object, Object>, Cloneable {
     /**
      * Creates ConversionHints with controlled modifiability.
      *
-     * @param modifiable
-     *         set true to create a modifiable hints instance
+     * @param modifiable set true to create a modifiable hints instance
      */
     public ConversionHints(final boolean modifiable) {
         this(null, modifiable);
@@ -349,8 +361,7 @@ public final class ConversionHints implements Map<Object, Object>, Cloneable {
     /**
      * Creates ConversionHints with the given key-value pairs.
      *
-     * @param init
-     *         the map of key-values
+     * @param init the map of key-values
      */
     public ConversionHints(final Map<? super Key, ?> init) {
         this(init, true);
@@ -359,10 +370,8 @@ public final class ConversionHints implements Map<Object, Object>, Cloneable {
     /**
      * Creates ParsingHints with the given key-value pairs and controlled modifiability.
      *
-     * @param init
-     *         the map of key-values
-     * @param modifiable
-     *         true if hints can be modified, false if not
+     * @param init       the map of key-values
+     * @param modifiable true if hints can be modified, false if not
      */
     public ConversionHints(final Map<? super Key, ?> init, final boolean modifiable) {
         if (init != null) {
@@ -376,10 +385,8 @@ public final class ConversionHints implements Map<Object, Object>, Cloneable {
      * Creates a ParsingHints with only a single key-value pair.
      * The result is unmodifiable.
      *
-     * @param key
-     *         the key
-     * @param value
-     *         the value for the key
+     * @param key   the key
+     * @param value the value for the key
      */
     public ConversionHints(final Key key, final Object value) {
         this(null, true);
@@ -550,9 +557,7 @@ public final class ConversionHints implements Map<Object, Object>, Cloneable {
         /**
          * Check if using the <code>value</code> with this Key makes sense.
          *
-         * @param value
-         *         value to check
-         *
+         * @param value value to check
          * @return true if the value is one of the allowed ones, false otherwise
          */
         public abstract boolean isCompatibleValue(Object value);

--- a/src/main/java/fi/fmi/avi/util/BulletinHeadingDecoder.java
+++ b/src/main/java/fi/fmi/avi/util/BulletinHeadingDecoder.java
@@ -1,6 +1,7 @@
 package fi.fmi.avi.util;
 
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -14,7 +15,8 @@ import fi.fmi.avi.model.bulletin.immutable.BulletinHeadingImpl;
 
 public class BulletinHeadingDecoder {
     private static final Pattern ABBREVIATED_HEADING = Pattern.compile(
-            "^(?<TT>[A-Z]{2})(?<AA>[A-Z]{2})(?<ii>[0-9]{2})\\s*(?<CCCC>[A-Z]{4})\\s*(?<YY>[0-9]{2})(?<GG>[0-9]{2})(?<gg>[0-9]{2})\\s*(?<BBB>(CC|RR|AA)[A-Z])?$");
+            "^(?<TT>[A-Z]{2})(?<AA>[A-Z]{2})(?<ii>[0-9]{2})\\s*(?<CCCC>[A-Z]{4})\\s*(?<YY>[0-9]{2})(?<GG>[0-9]{2})(?<gg>[0-9]{2})\\s*(?<BBB>[A-Z]+)?$");
+    private static final Pattern AUGMENTATION_INDICATOR = Pattern.compile("(?<BBB>(CC|RR|AA)[A-Z])?");
 
     public static BulletinHeading decode(final String input, final ConversionHints hints) throws IllegalArgumentException {
         final Matcher m = ABBREVIATED_HEADING.matcher(input);
@@ -23,13 +25,29 @@ public class BulletinHeadingDecoder {
                     + "or 'T1T2A1A2ii CCCC YYGGgg[ BBB]' as defined in "
                     + "WMO-No. 386 Manual on the Global Telecommunication System, 2015 edition (updated 2017)");
         }
-        final String bbb = m.group("BBB");
+
         BulletinHeading.Type type = BulletinHeading.Type.NORMAL;
         Integer bulletinAugmentationNumber = null;
+
+        String bbb = m.group("BBB");
         if (bbb != null) {
+            if (hints != null && hints.containsKey(ConversionHints.KEY_BULLETIN_HEADING_AUGMENTATION_INDICATOR_EXTENSION)) {
+                final Function<String, String> extension = (Function<String, String>) hints.get(
+                        ConversionHints.KEY_BULLETIN_HEADING_AUGMENTATION_INDICATOR_EXTENSION);
+                bbb = extension.apply(bbb);
+            }
+
+            final Matcher bbbMatcher = AUGMENTATION_INDICATOR.matcher(bbb);
+            if (!bbbMatcher.matches()) {
+                throw new IllegalArgumentException("String '" + input + "' does not match the Abbreviated heading formats 'T1T2A1A2iiCCCCYYGGgg[BBB]' "
+                        + "or 'T1T2A1A2ii CCCC YYGGgg[ BBB]' as defined in "
+                        + "WMO-No. 386 Manual on the Global Telecommunication System, 2015 edition (updated 2017)");
+            }
+
             type = BulletinHeading.Type.fromCode(bbb.substring(0, 2));
             bulletinAugmentationNumber = bbb.charAt(2) - 'A' + 1;
         }
+
         final DataTypeDesignatorT1 t1 = DataTypeDesignatorT1.fromCode(m.group("TT").charAt(0));
         final char t2Code = m.group("TT").charAt(1);
         final DataTypeDesignatorT2 t2 = t1.t2FromCode(t2Code)

--- a/src/main/java/fi/fmi/avi/util/BulletinHeadingDecoder.java
+++ b/src/main/java/fi/fmi/avi/util/BulletinHeadingDecoder.java
@@ -1,7 +1,6 @@
 package fi.fmi.avi.util;
 
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -14,16 +13,18 @@ import fi.fmi.avi.model.bulletin.DataTypeDesignatorT2;
 import fi.fmi.avi.model.bulletin.immutable.BulletinHeadingImpl;
 
 public class BulletinHeadingDecoder {
+    // Abbreviated heading with lenient augmentation indicator
     private static final Pattern ABBREVIATED_HEADING = Pattern.compile(
-            "^(?<TT>[A-Z]{2})(?<AA>[A-Z]{2})(?<ii>[0-9]{2})\\s*(?<CCCC>[A-Z]{4})\\s*(?<YY>[0-9]{2})(?<GG>[0-9]{2})(?<gg>[0-9]{2})\\s*(?<BBB>[A-Z]+)?$");
+            "^(?<TT>[A-Z]{2})(?<AA>[A-Z]{2})(?<ii>[0-9]{2})\\s*(?<CCCC>[A-Z]{4})\\s*(?<YY>[0-9]{2})(?<GG>[0-9]{2})(?<gg>[0-9]{2})\\s*(?<BBB>[A-Z0-9]+)?$");
+    // Strict augmentation indicator
     private static final Pattern AUGMENTATION_INDICATOR = Pattern.compile("(?<BBB>(CC|RR|AA)[A-Z])?");
 
     public static BulletinHeading decode(final String input, final ConversionHints hints) throws IllegalArgumentException {
         final Matcher m = ABBREVIATED_HEADING.matcher(input);
+        final String illegalInputMessage = "String '" + input + "' does not match the Abbreviated heading formats 'T1T2A1A2iiCCCCYYGGgg[BBB]' "
+                + "or 'T1T2A1A2ii CCCC YYGGgg[ BBB]' as defined in " + "WMO-No. 386 Manual on the Global Telecommunication System, 2015 edition (updated 2017)";
         if (!m.matches()) {
-            throw new IllegalArgumentException("String '" + input + "' does not match the Abbreviated heading formats 'T1T2A1A2iiCCCCYYGGgg[BBB]' "
-                    + "or 'T1T2A1A2ii CCCC YYGGgg[ BBB]' as defined in "
-                    + "WMO-No. 386 Manual on the Global Telecommunication System, 2015 edition (updated 2017)");
+            throw new IllegalArgumentException(illegalInputMessage);
         }
 
         BulletinHeading.Type type = BulletinHeading.Type.NORMAL;
@@ -32,16 +33,15 @@ public class BulletinHeadingDecoder {
         String bbb = m.group("BBB");
         if (bbb != null) {
             if (hints != null && hints.containsKey(ConversionHints.KEY_BULLETIN_HEADING_AUGMENTATION_INDICATOR_EXTENSION)) {
-                final Function<String, String> extension = (Function<String, String>) hints.get(
-                        ConversionHints.KEY_BULLETIN_HEADING_AUGMENTATION_INDICATOR_EXTENSION);
-                bbb = extension.apply(bbb);
+                final Object value = hints.get(ConversionHints.KEY_BULLETIN_HEADING_AUGMENTATION_INDICATOR_EXTENSION);
+                if (value instanceof BulletinHeadingIndicatorInterpreter) {
+                    bbb = ((BulletinHeadingIndicatorInterpreter) value).apply(bbb);
+                }
             }
 
             final Matcher bbbMatcher = AUGMENTATION_INDICATOR.matcher(bbb);
             if (!bbbMatcher.matches()) {
-                throw new IllegalArgumentException("String '" + input + "' does not match the Abbreviated heading formats 'T1T2A1A2iiCCCCYYGGgg[BBB]' "
-                        + "or 'T1T2A1A2ii CCCC YYGGgg[ BBB]' as defined in "
-                        + "WMO-No. 386 Manual on the Global Telecommunication System, 2015 edition (updated 2017)");
+                throw new IllegalArgumentException(illegalInputMessage);
             }
 
             type = BulletinHeading.Type.fromCode(bbb.substring(0, 2));

--- a/src/main/java/fi/fmi/avi/util/BulletinHeadingIndicatorInterpreter.java
+++ b/src/main/java/fi/fmi/avi/util/BulletinHeadingIndicatorInterpreter.java
@@ -1,0 +1,10 @@
+package fi.fmi.avi.util;
+
+import java.util.function.Function;
+
+/**
+ * The result of this function should be a valid BBB indicator as defined in WMO-No. 386 Manual on the Global Telecommunication System, 2015 edition (updated
+ * 2017).
+ */
+public interface BulletinHeadingIndicatorInterpreter extends Function<String, String> {
+}

--- a/src/test/java/fi/fmi/avi/util/BulletinHeadingDecoderTest.java
+++ b/src/test/java/fi/fmi/avi/util/BulletinHeadingDecoderTest.java
@@ -1,0 +1,90 @@
+package fi.fmi.avi.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.common.collect.ImmutableMap;
+
+import fi.fmi.avi.converter.ConversionHints;
+import fi.fmi.avi.model.PartialOrCompleteTimeInstant;
+import fi.fmi.avi.model.bulletin.BulletinHeading;
+import fi.fmi.avi.model.bulletin.DataTypeDesignatorT1;
+import fi.fmi.avi.model.bulletin.DataTypeDesignatorT2;
+import fi.fmi.avi.model.bulletin.immutable.BulletinHeadingImpl;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+@RunWith(JUnitParamsRunner.class)
+public class BulletinHeadingDecoderTest {
+
+    private static final String GEOGRAPHICAL_DESIGNATOR = "FI";
+    private static final int DEFAULT_BULLETIN_NUMBER = 31;
+    private static final String DEFAULT_LOCATION_INDICATOR = "EFLK";
+    private static final PartialOrCompleteTimeInstant ISSUE_TIME = PartialOrCompleteTimeInstant.createDayHourInstant("250200");
+    private static final PartialOrCompleteTimeInstant SIGMET_ISSUE_TIME = PartialOrCompleteTimeInstant.createDayHourInstant("231008");
+
+    private static final BulletinHeadingImpl TAF_BULLETIN_HEADING = BulletinHeadingImpl.builder()//
+            .setGeographicalDesignator(GEOGRAPHICAL_DESIGNATOR)//
+            .setLocationIndicator(DEFAULT_LOCATION_INDICATOR)//
+            .setBulletinNumber(DEFAULT_BULLETIN_NUMBER)//
+            .setType(BulletinHeading.Type.NORMAL)//
+            .setDataTypeDesignatorT1ForTAC(DataTypeDesignatorT1.FORECASTS)//
+            .setDataTypeDesignatorT2(DataTypeDesignatorT2.ForecastsDataTypeDesignatorT2.FCT_AERODROME_VT_LONG)//
+            .setIssueTime(ISSUE_TIME).build();
+    private static final BulletinHeadingImpl SIGMET_BULLETIN_HEADING = BulletinHeadingImpl.builder()//
+            .setDataTypeDesignatorT2(DataTypeDesignatorT2.WarningsDataTypeDesignatorT2.WRN_SIGMET)//
+            .setGeographicalDesignator(GEOGRAPHICAL_DESIGNATOR)//
+            .setType(BulletinHeading.Type.NORMAL)//
+            .setLocationIndicator(DEFAULT_LOCATION_INDICATOR)//
+            .setBulletinNumber(DEFAULT_BULLETIN_NUMBER)//
+            .setDataTypeDesignatorT1ForTAC(DataTypeDesignatorT1.WARNINGS)//
+            .setDataTypeDesignatorT2(DataTypeDesignatorT2.WarningsDataTypeDesignatorT2.WRN_SIGMET)//
+            .setIssueTime(SIGMET_ISSUE_TIME).build();
+
+    private static final Map<String, String> AUGMENTATION_INDICATOR_REPLACEMENTS = ImmutableMap.of("COR", "CCA", "RTD", "RRA", "AMD", "AAA");
+    private static final ConversionHints EXTENDED_AUGMENTATION_IDENTIFIERS = new ConversionHints();
+
+    @BeforeClass
+    public static void setUp() {
+        EXTENDED_AUGMENTATION_IDENTIFIERS.put(ConversionHints.KEY_BULLETIN_HEADING_AUGMENTATION_INDICATOR_EXTENSION,
+                (Function<String, String>) key -> AUGMENTATION_INDICATOR_REPLACEMENTS.getOrDefault(key, key));
+    }
+
+    @Test
+    @Parameters
+    public void decode_bulletin_headings(final String input, final BulletinHeading expected, final ConversionHints conversionHints) {
+        assertEquals(BulletinHeadingDecoder.decode(input, conversionHints), expected);
+    }
+
+    public Object parametersForDecode_bulletin_headings() {
+        return new Object[] {//
+                new Object[] { "FTFI31 EFLK 250200", TAF_BULLETIN_HEADING, ConversionHints.EMPTY },//
+                new Object[] { "FCFI31 EFLK 250200 AAB", TAF_BULLETIN_HEADING.toBuilder()
+                        .setDataTypeDesignatorT2(DataTypeDesignatorT2.ForecastsDataTypeDesignatorT2.FCT_AERODROME_VT_SHORT)
+                        .setType(BulletinHeading.Type.AMENDED)
+                        .setBulletinAugmentationNumber(2).build(), ConversionHints.EMPTY },//
+                new Object[] { "FTFI31 EFLK 250200 CCC",
+                        TAF_BULLETIN_HEADING.toBuilder().setType(BulletinHeading.Type.CORRECTED).setBulletinAugmentationNumber(3).build(),
+                        ConversionHints.EMPTY },//
+                new Object[] { "FTFI32 AAAA 250200 RRA", TAF_BULLETIN_HEADING.toBuilder()
+                        .setType(BulletinHeading.Type.DELAYED)
+                        .setBulletinAugmentationNumber(1)
+                        .setBulletinNumber(32)
+                        .setLocationIndicator("AAAA").build(), ConversionHints.EMPTY },//
+                // Extended augmentation indicators
+                new Object[] { "FTFI31 EFLK 250200 BLAH",
+                        TAF_BULLETIN_HEADING.toBuilder().setType(BulletinHeading.Type.CORRECTED).setBulletinAugmentationNumber(3).build(),
+                        EXTENDED_AUGMENTATION_IDENTIFIERS },//
+                // SIGMETs
+                new Object[] { "WSFI31 EFLK 231008", SIGMET_BULLETIN_HEADING, ConversionHints.EMPTY },
+                new Object[] { "WSFI32 AAAA 231008", SIGMET_BULLETIN_HEADING.toBuilder().setBulletinNumber(32).setLocationIndicator("AAAA").build(),
+                        ConversionHints.EMPTY } };
+    }
+
+}

--- a/src/test/java/fi/fmi/avi/util/BulletinHeadingDecoderTest.java
+++ b/src/test/java/fi/fmi/avi/util/BulletinHeadingDecoderTest.java
@@ -97,7 +97,7 @@ public class BulletinHeadingDecoderTest {
                         TAF_BULLETIN_HEADING.toBuilder().setType(BulletinHeading.Type.AMENDED).setBulletinAugmentationNumber(1).build(),
                         EXTENDED_AUGMENTATION_IDENTIFIERS, IllegalArgumentException.class },//
                 new Object[] { "FTFI31 EFLK 250200 RTD",
-                        TAF_BULLETIN_HEADING.toBuilder().setType(BulletinHeading.Type.AMENDED).setBulletinAugmentationNumber(1).build(), ConversionHints.EMPTY,
+                        TAF_BULLETIN_HEADING.toBuilder().setType(BulletinHeading.Type.DELAYED).setBulletinAugmentationNumber(1).build(), ConversionHints.EMPTY,
                         IllegalArgumentException.class },//
                 // SIGMETs
                 new Object[] { "WSFI31 EFLK 231008", SIGMET_BULLETIN_HEADING, ConversionHints.EMPTY, null },


### PR DESCRIPTION
Allows custom interpretation logic when decoding bulletin heading augmentation indicators (BBB). This is useful because real world messages may not comply with the WMO specification. Headings such as "SAFI33 EFHK 200720 RTD" can be interpreted to mean "SAFI33 EFHK 200720 RRA" through a ConversionHint.