### PR TITLE
Tac issue 63

### DIFF
--- a/src/main/java/fi/fmi/avi/model/swx/SpaceWeatherRegion.java
+++ b/src/main/java/fi/fmi/avi/model/swx/SpaceWeatherRegion.java
@@ -17,12 +17,12 @@ public interface SpaceWeatherRegion extends AviationWeatherMessageOrCollection {
     Optional<Double> getLongitudeLimitMaximum();
 
     enum SpaceWeatherLocation {
-        HIGH_NORTHERN_HEMISPHERE("HNH", -90d, -60d),
-        MIDDLE_NORTHERN_HEMISPHERE("MNH", -60d, -30d),
-        EQUATORIAL_LATITUDES_NORTHERN_HEMISPHERE("EQN", -30d, 0d),
-        EQUATORIAL_LATITUDES_SOUTHERN_HEMISPHERE("EQS", 0d, 30d),
-        MIDDLE_LATITUDES_SOUTHERN_HEMISPHERE("MSH", 30d, 60d),
-        HIGH_LATITUDES_SOUTHERN_HEMISPHERE("HSH", 60d, 90d),
+        HIGH_NORTHERN_HEMISPHERE("HNH", 90d, 60d),
+        MIDDLE_NORTHERN_HEMISPHERE("MNH", 60d, 30d),
+        EQUATORIAL_LATITUDES_NORTHERN_HEMISPHERE("EQN", 30d, 0d),
+        EQUATORIAL_LATITUDES_SOUTHERN_HEMISPHERE("EQS", 0d, -30d),
+        MIDDLE_LATITUDES_SOUTHERN_HEMISPHERE("MSH", -30d, -60d),
+        HIGH_LATITUDES_SOUTHERN_HEMISPHERE("HSH", -60d, -90d),
         DAYLIGHT_SIDE("DAYLIGHT_SIDE", Double.NaN, Double.NaN);
 
         private static final String CODELIST_BASE = "http://codes.wmo.int/49-2/SpaceWxLocation/";


### PR DESCRIPTION
Northern latitudes were incorrectly marked down as negatives and southern latitudes as positives.

Changes related to bug reported in issue 63 in the fmi-avi-messageconverter-tac (https://github.com/fmidev/fmi-avi-messageconverter-tac/issues/63)
