### PR TITLE
Make reportStatus non-optional

### DIFF
--- a/src/main/java/fi/fmi/avi/model/AerodromeWeatherMessageBuilderHelper.java
+++ b/src/main/java/fi/fmi/avi/model/AerodromeWeatherMessageBuilderHelper.java
@@ -1,0 +1,40 @@
+package fi.fmi.avi.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.BiConsumer;
+
+import fi.fmi.avi.model.immutable.AerodromeImpl;
+
+public final class AerodromeWeatherMessageBuilderHelper {
+    private AerodromeWeatherMessageBuilderHelper() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Copy properties declared in {@link AerodromeWeatherMessage} from provided {@code value} to {@code builder} using provided setters.
+     *
+     * <p>
+     * This method exists for completeness safety. Whenever the {@link AerodromeWeatherMessage} interface changes, applying changes here will enforce to
+     * conform to changes in all builders using this method. This ensures that changes will not get unnoticed in builder classes.
+     * </p>
+     *
+     * @param <T>
+     *         type of {@code value}
+     * @param <B>
+     *         type of {@code builder}
+     * @param builder
+     *         builder to copy properties to
+     * @param value
+     *         value object to copy properties from
+     * @param setAerodrome
+     *         setter for aerodrome
+     */
+    public static <T extends AerodromeWeatherMessage, B> void copyFrom(final B builder, final T value,  //
+            final BiConsumer<B, Aerodrome> setAerodrome) {
+        requireNonNull(value, "value");
+        requireNonNull(builder, "builder");
+        setAerodrome.accept(builder, AerodromeImpl.immutableCopyOf(value.getAerodrome()));
+    }
+
+}

--- a/src/main/java/fi/fmi/avi/model/AirTrafficServicesUnitWeatherMessageBuilderHelper.java
+++ b/src/main/java/fi/fmi/avi/model/AirTrafficServicesUnitWeatherMessageBuilderHelper.java
@@ -1,0 +1,43 @@
+package fi.fmi.avi.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.BiConsumer;
+
+import fi.fmi.avi.model.immutable.UnitPropertyGroupImpl;
+
+public final class AirTrafficServicesUnitWeatherMessageBuilderHelper {
+    private AirTrafficServicesUnitWeatherMessageBuilderHelper() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Copy properties declared in {@link AirTrafficServicesUnitWeatherMessage} from provided {@code value} to {@code builder} using provided setters.
+     *
+     * <p>
+     * This method exists for completeness safety. Whenever the {@link AirTrafficServicesUnitWeatherMessage} interface changes, applying changes here will enforce to
+     * conform to changes in all builders using this method. This ensures that changes will not get unnoticed in builder classes.
+     * </p>
+     *
+     * @param <T>
+     *         type of {@code value}
+     * @param <B>
+     *         type of {@code builder}
+     * @param builder
+     *         builder to copy properties to
+     * @param value
+     *         value object to copy properties from
+     * @param setIssuingAirTrafficServicesUnit
+     *         setter for issuingAirTrafficServicesUnit
+     * @param setMeteorologicalWatchOffice
+     *         setter for meteorologicalWatchOffice
+     */
+    public static <T extends AirTrafficServicesUnitWeatherMessage, B> void copyFrom(final B builder, final T value,  //
+            final BiConsumer<B, UnitPropertyGroup> setIssuingAirTrafficServicesUnit, //
+            final BiConsumer<B, UnitPropertyGroup> setMeteorologicalWatchOffice) {
+        requireNonNull(value, "value");
+        requireNonNull(builder, "builder");
+        setIssuingAirTrafficServicesUnit.accept(builder, UnitPropertyGroupImpl.immutableCopyOf(value.getIssuingAirTrafficServicesUnit()));
+        setMeteorologicalWatchOffice.accept(builder, UnitPropertyGroupImpl.immutableCopyOf(value.getMeteorologicalWatchOffice()));
+    }
+}

--- a/src/main/java/fi/fmi/avi/model/AviationCodeListUser.java
+++ b/src/main/java/fi/fmi/avi/model/AviationCodeListUser.java
@@ -651,13 +651,17 @@ public interface AviationCodeListUser {
 
     }
 
+    @Deprecated
     enum SigmetAirmetReportStatus {
-        NORMAL(0), CANCELLATION(1);
+        NORMAL(0, AviationWeatherMessage.ReportStatus.NORMAL), //
+        CANCELLATION(1, AviationWeatherMessage.ReportStatus.NORMAL);
 
         private final int code;
+        private final AviationWeatherMessage.ReportStatus reportStatus;
 
-        SigmetAirmetReportStatus(final int code) {
+        SigmetAirmetReportStatus(final int code, final AviationWeatherMessage.ReportStatus reportStatus) {
             this.code = code;
+            this.reportStatus = reportStatus;
         }
 
         public static SigmetAirmetReportStatus fromInt(final int code) {
@@ -671,8 +675,21 @@ public interface AviationCodeListUser {
             }
         }
 
+        public static SigmetAirmetReportStatus fromReportStatus(final AviationWeatherMessage.ReportStatus reportStatus, final boolean cancelMessage) {
+            requireNonNull(reportStatus, "reportStatus");
+            return cancelMessage ? CANCELLATION : NORMAL;
+        }
+
         public int getCode() {
             return this.code;
+        }
+
+        public AviationWeatherMessage.ReportStatus getReportStatus() {
+            return reportStatus;
+        }
+
+        public boolean isCancelMessage() {
+            return this == CANCELLATION;
         }
     }
 

--- a/src/main/java/fi/fmi/avi/model/AviationCodeListUser.java
+++ b/src/main/java/fi/fmi/avi/model/AviationCodeListUser.java
@@ -57,13 +57,18 @@ public interface AviationCodeListUser {
             "http://codes.wmo.int/49-2/observation-type/iwxxm/2" + ".1/AIRMETEvolvingConditionCollectionAnalysis";
     String CODELIST_VALUE_WEATHERCAUSINGVISIBILITYREDUCTION = "http://codes.wmo.int/49-2/WeatherCausingVisibilityReduction";
 
+    @Deprecated
     enum MetarStatus {
-        NORMAL(0), CORRECTION(1), MISSING(2);
+        NORMAL(0, AviationWeatherMessage.ReportStatus.NORMAL), //
+        CORRECTION(1, AviationWeatherMessage.ReportStatus.CORRECTION), //
+        MISSING(2, AviationWeatherMessage.ReportStatus.NORMAL);
 
         private final int code;
+        private final AviationWeatherMessage.ReportStatus reportStatus;
 
-        MetarStatus(final int code) {
+        MetarStatus(final int code, final AviationWeatherMessage.ReportStatus reportStatus) {
             this.code = code;
+            this.reportStatus = reportStatus;
         }
 
         public static MetarStatus fromInt(final int code) {
@@ -79,10 +84,33 @@ public interface AviationCodeListUser {
             }
         }
 
+        public static MetarStatus fromReportStatus(final AviationWeatherMessage.ReportStatus reportStatus, final boolean missingMessage) {
+            requireNonNull(reportStatus, "reportStatus");
+            if (missingMessage) {
+                return MISSING;
+            }
+            switch (reportStatus) {
+                case CORRECTION:
+                case AMENDMENT:
+                    return CORRECTION;
+                case NORMAL:
+                    return NORMAL;
+                default:
+                    throw new IllegalArgumentException("Unknown reportStatus: " + reportStatus);
+            }
+        }
+
         public int getCode() {
             return this.code;
         }
 
+        public AviationWeatherMessage.ReportStatus getReportStatus() {
+            return reportStatus;
+        }
+
+        public boolean isMissingMessage() {
+            return this == MISSING;
+        }
     }
 
     @Deprecated

--- a/src/main/java/fi/fmi/avi/model/AviationWeatherMessage.java
+++ b/src/main/java/fi/fmi/avi/model/AviationWeatherMessage.java
@@ -15,6 +15,29 @@ import fi.fmi.avi.model.AviationCodeListUser.PermissibleUsageReason;
 public interface AviationWeatherMessage extends AviationWeatherMessageOrCollection {
 
     /**
+     * See https://schemas.wmo.int/iwxxm/3.0/common.xsd
+     *
+     * @return report status
+     */
+    ReportStatus getReportStatus();
+
+    /**
+     * Returns the issue time of the message.
+     * The returned {@link PartialOrCompleteTimeInstant} may or may not contain
+     * a completely resolved date time depending on which information it was
+     * created with.
+     *
+     * Note: For valid AviationWeatherMessages the issue time is an important field and
+     * should exist in most cases. This field is optional to allow handling
+     * of incomplete messages without the issue time information.
+     *
+     * @return the fully resolved issue time
+     *
+     * @see PartialOrCompleteTimeInstant.Builder#completePartialAt(YearMonth)
+     */
+    Optional<PartialOrCompleteTimeInstant> getIssueTime();
+
+    /**
      * Returns the remarks, if included in the message.
      * in TAC remarks are provided at the end of the message
      * after the 'RMK' token.
@@ -100,30 +123,6 @@ public interface AviationWeatherMessage extends AviationWeatherMessageOrCollecti
      * @return true if all time references are complete, false otherwise
      */
     boolean areAllTimeReferencesComplete();
-
-
-    /**
-     * Returns the issue time of the message.
-     * The returned {@link PartialOrCompleteTimeInstant} may or may not contain
-     * a completely resolved date time depending on which information it was
-     * created with.
-     *
-     * Note: For valid AviationWeatherMessages the issue time is an important field and
-     * should exist in most cases. This field is optional to allow handling
-     * of incomplete messages without the issue time information.
-     *
-     * @return the fully resolved issue time
-     *
-     * @see PartialOrCompleteTimeInstant.Builder#completePartialAt(YearMonth)
-     */
-    Optional<PartialOrCompleteTimeInstant> getIssueTime();
-
-    /**
-     * See https://schemas.wmo.int/iwxxm/3.0/common.xsd
-     *
-     * @return report status
-     */
-    ReportStatus getReportStatus();
 
     enum ReportStatus {
         CORRECTION, AMENDMENT, NORMAL

--- a/src/main/java/fi/fmi/avi/model/AviationWeatherMessage.java
+++ b/src/main/java/fi/fmi/avi/model/AviationWeatherMessage.java
@@ -119,15 +119,13 @@ public interface AviationWeatherMessage extends AviationWeatherMessageOrCollecti
     Optional<PartialOrCompleteTimeInstant> getIssueTime();
 
     /**
-     *See https://schemas.wmo.int/iwxxm/3.0/common.xsd
+     * See https://schemas.wmo.int/iwxxm/3.0/common.xsd
      *
      * @return report status
      */
-    Optional<ReportStatus> getReportStatus();
+    ReportStatus getReportStatus();
 
-    public enum ReportStatus {
-        CORRECTION,
-        AMENDMENT,
-        NORMAL
+    enum ReportStatus {
+        CORRECTION, AMENDMENT, NORMAL
     }
 }

--- a/src/main/java/fi/fmi/avi/model/AviationWeatherMessageBuilderHelper.java
+++ b/src/main/java/fi/fmi/avi/model/AviationWeatherMessageBuilderHelper.java
@@ -28,6 +28,10 @@ public final class AviationWeatherMessageBuilderHelper {
      *         builder to copy properties to
      * @param value
      *         value object to copy properties from
+     * @param setReportStatus
+     *         setter for reportStatus
+     * @param setIssueTime
+     *         setter for issueTime
      * @param setRemarks
      *         setter for remarks
      * @param setPermissibleUsage
@@ -39,7 +43,7 @@ public final class AviationWeatherMessageBuilderHelper {
      * @param setTranslated
      *         setter for translated
      * @param setTranslatedBulletinID
-     *         stter for translatedBulletinID
+     *         setter for translatedBulletinID
      * @param setTranslatedBulletinReceptionTime
      *         setter for translatedBulletinReceptionTime
      * @param setTranslationCentreDesignator
@@ -50,12 +54,10 @@ public final class AviationWeatherMessageBuilderHelper {
      *         setter for translationTime
      * @param setTranslatedTAC
      *         setter for translatedTAC
-     * @param setIssueTime
-     *         setter for issueTime
-     * @param setReportStatus
-     *         setter for reportStatus
      */
     public static <T extends AviationWeatherMessage, B> void copyFrom(final B builder, final T value,  //
+            final BiConsumer<B, AviationWeatherMessage.ReportStatus> setReportStatus, //
+            final BiConsumer<B, Optional<PartialOrCompleteTimeInstant>> setIssueTime, //
             final BiConsumer<B, Optional<List<String>>> setRemarks, //
             final BiConsumer<B, Optional<AviationCodeListUser.PermissibleUsage>> setPermissibleUsage, //
             final BiConsumer<B, Optional<AviationCodeListUser.PermissibleUsageReason>> setPermissibleUsageReason, //
@@ -66,9 +68,7 @@ public final class AviationWeatherMessageBuilderHelper {
             final BiConsumer<B, Optional<String>> setTranslationCentreDesignator, //
             final BiConsumer<B, Optional<String>> setTranslationCentreName, //
             final BiConsumer<B, Optional<ZonedDateTime>> setTranslationTime, //
-            final BiConsumer<B, Optional<String>> setTranslatedTAC, //
-            final BiConsumer<B, Optional<PartialOrCompleteTimeInstant>> setIssueTime, //
-            final BiConsumer<B, AviationWeatherMessage.ReportStatus> setReportStatus) {
+            final BiConsumer<B, Optional<String>> setTranslatedTAC) {
         requireNonNull(value, "value");
         requireNonNull(builder, "builder");
         setRemarks.accept(builder, value.getRemarks().map(BuilderHelper::toImmutableList));

--- a/src/main/java/fi/fmi/avi/model/AviationWeatherMessageBuilderHelper.java
+++ b/src/main/java/fi/fmi/avi/model/AviationWeatherMessageBuilderHelper.java
@@ -68,7 +68,7 @@ public final class AviationWeatherMessageBuilderHelper {
             final BiConsumer<B, Optional<ZonedDateTime>> setTranslationTime, //
             final BiConsumer<B, Optional<String>> setTranslatedTAC, //
             final BiConsumer<B, Optional<PartialOrCompleteTimeInstant>> setIssueTime, //
-            final BiConsumer<B, Optional<AviationWeatherMessage.ReportStatus>> setReportStatus) {
+            final BiConsumer<B, AviationWeatherMessage.ReportStatus> setReportStatus) {
         requireNonNull(value, "value");
         requireNonNull(builder, "builder");
         setRemarks.accept(builder, value.getRemarks().map(BuilderHelper::toImmutableList));

--- a/src/main/java/fi/fmi/avi/model/AviationWeatherMessageBuilderHelper.java
+++ b/src/main/java/fi/fmi/avi/model/AviationWeatherMessageBuilderHelper.java
@@ -1,0 +1,88 @@
+package fi.fmi.avi.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+public final class AviationWeatherMessageBuilderHelper {
+    private AviationWeatherMessageBuilderHelper() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Copy properties declared in {@link AviationWeatherMessage} from provided {@code value} to {@code builder} using provided setters.
+     *
+     * <p>
+     * This method exists for completeness safety. Whenever the {@link AviationWeatherMessage} interface changes, applying changes here will enforce to
+     * conform to changes in all builders using this method. This ensures that changes will not get unnoticed in builder classes.
+     * </p>
+     *
+     * @param <T>
+     *         type of {@code value}
+     * @param <B>
+     *         type of {@code builder}
+     * @param builder
+     *         builder to copy properties to
+     * @param value
+     *         value object to copy properties from
+     * @param setRemarks
+     *         setter for remarks
+     * @param setPermissibleUsage
+     *         setter for permissibleUsage
+     * @param setPermissibleUsageReason
+     *         setter for permissibleUsageReason
+     * @param setPermissibleUsageSupplementary
+     *         setter for permissibleUsageSupplementary
+     * @param setTranslated
+     *         setter for translated
+     * @param setTranslatedBulletinID
+     *         stter for translatedBulletinID
+     * @param setTranslatedBulletinReceptionTime
+     *         setter for translatedBulletinReceptionTime
+     * @param setTranslationCentreDesignator
+     *         setter for translationCentreDesignator
+     * @param setTranslationCentreName
+     *         setter for translationCentreName
+     * @param setTranslationTime
+     *         setter for translationTime
+     * @param setTranslatedTAC
+     *         setter for translatedTAC
+     * @param setIssueTime
+     *         setter for issueTime
+     * @param setReportStatus
+     *         setter for reportStatus
+     */
+    public static <T extends AviationWeatherMessage, B> void copyFrom(final B builder, final T value,  //
+            final BiConsumer<B, Optional<List<String>>> setRemarks, //
+            final BiConsumer<B, Optional<AviationCodeListUser.PermissibleUsage>> setPermissibleUsage, //
+            final BiConsumer<B, Optional<AviationCodeListUser.PermissibleUsageReason>> setPermissibleUsageReason, //
+            final BiConsumer<B, Optional<String>> setPermissibleUsageSupplementary, //
+            final BiConsumer<B, Boolean> setTranslated, //
+            final BiConsumer<B, Optional<String>> setTranslatedBulletinID, //
+            final BiConsumer<B, Optional<ZonedDateTime>> setTranslatedBulletinReceptionTime, //
+            final BiConsumer<B, Optional<String>> setTranslationCentreDesignator, //
+            final BiConsumer<B, Optional<String>> setTranslationCentreName, //
+            final BiConsumer<B, Optional<ZonedDateTime>> setTranslationTime, //
+            final BiConsumer<B, Optional<String>> setTranslatedTAC, //
+            final BiConsumer<B, Optional<PartialOrCompleteTimeInstant>> setIssueTime, //
+            final BiConsumer<B, Optional<AviationWeatherMessage.ReportStatus>> setReportStatus) {
+        requireNonNull(value, "value");
+        requireNonNull(builder, "builder");
+        setRemarks.accept(builder, value.getRemarks().map(BuilderHelper::toImmutableList));
+        setPermissibleUsage.accept(builder, value.getPermissibleUsage());
+        setPermissibleUsageReason.accept(builder, value.getPermissibleUsageReason());
+        setPermissibleUsageSupplementary.accept(builder, value.getPermissibleUsageSupplementary());
+        setTranslated.accept(builder, value.isTranslated());
+        setTranslatedBulletinID.accept(builder, value.getTranslatedBulletinID());
+        setTranslatedBulletinReceptionTime.accept(builder, value.getTranslatedBulletinReceptionTime());
+        setTranslationCentreDesignator.accept(builder, value.getTranslationCentreDesignator());
+        setTranslationCentreName.accept(builder, value.getTranslationCentreName());
+        setTranslationTime.accept(builder, value.getTranslationTime());
+        setTranslatedTAC.accept(builder, value.getTranslatedTAC());
+        setIssueTime.accept(builder, value.getIssueTime());
+        setReportStatus.accept(builder, value.getReportStatus());
+    }
+}

--- a/src/main/java/fi/fmi/avi/model/BuilderHelper.java
+++ b/src/main/java/fi/fmi/avi/model/BuilderHelper.java
@@ -1,0 +1,53 @@
+package fi.fmi.avi.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public final class BuilderHelper {
+    private BuilderHelper() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Return an immutable copy of provided list of elements known to be immutable.
+     * If elements may not be immutable, use {@link #toImmutableList(List, Function)} instead.
+     *
+     * @param list
+     *         source list
+     * @param <T>
+     *         base type of elements
+     *
+     * @return immutable copy
+     */
+    public static <T> List<T> toImmutableList(final List<T> list) {
+        requireNonNull(list, "list");
+        return list.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(new ArrayList<>(list));
+    }
+
+    /**
+     * Return an immutable copy of provided list converting each element to immutable.
+     *
+     * @param list
+     *         source list
+     * @param toImmutable
+     *         function converting element to immutable
+     * @param <T>
+     *         base type of elements
+     * @param <I>
+     *         immutable type of elements
+     *
+     * @return immutable copy
+     */
+    public static <T, I extends T> List<T> toImmutableList(final List<T> list, final Function<T, I> toImmutable) {
+        requireNonNull(list, "list");
+        requireNonNull(toImmutable, "toImmutable");
+        return list.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(list.stream()//
+                .map(toImmutable)//
+                .collect(Collectors.toList()));
+    }
+}

--- a/src/main/java/fi/fmi/avi/model/SIGMETAIRMET.java
+++ b/src/main/java/fi/fmi/avi/model/SIGMETAIRMET.java
@@ -1,10 +1,16 @@
 package fi.fmi.avi.model;
 
-public interface SIGMETAIRMET  extends AirTrafficServicesUnitWeatherMessage, AviationCodeListUser {
+public interface SIGMETAIRMET extends AirTrafficServicesUnitWeatherMessage, AviationCodeListUser {
         String getSequenceNumber();
+
         PartialOrCompleteTimePeriod getValidityPeriod();
 
         Airspace getAirspace();
 
-        SigmetAirmetReportStatus getStatus();
+        @Deprecated
+        default SigmetAirmetReportStatus getStatus() {
+                return SigmetAirmetReportStatus.fromReportStatus(getReportStatus().orElse(ReportStatus.NORMAL), isCancelMessage());
+        }
+
+        boolean isCancelMessage();
 }

--- a/src/main/java/fi/fmi/avi/model/SIGMETAIRMET.java
+++ b/src/main/java/fi/fmi/avi/model/SIGMETAIRMET.java
@@ -1,16 +1,16 @@
 package fi.fmi.avi.model;
 
 public interface SIGMETAIRMET extends AirTrafficServicesUnitWeatherMessage, AviationCodeListUser {
-        String getSequenceNumber();
+    String getSequenceNumber();
 
-        PartialOrCompleteTimePeriod getValidityPeriod();
+    PartialOrCompleteTimePeriod getValidityPeriod();
 
-        Airspace getAirspace();
+    Airspace getAirspace();
 
-        @Deprecated
-        default SigmetAirmetReportStatus getStatus() {
-                return SigmetAirmetReportStatus.fromReportStatus(getReportStatus().orElse(ReportStatus.NORMAL), isCancelMessage());
-        }
+    @Deprecated
+    default SigmetAirmetReportStatus getStatus() {
+        return SigmetAirmetReportStatus.fromReportStatus(getReportStatus(), isCancelMessage());
+    }
 
-        boolean isCancelMessage();
+    boolean isCancelMessage();
 }

--- a/src/main/java/fi/fmi/avi/model/SIGMETAIRMETBuilderHelper.java
+++ b/src/main/java/fi/fmi/avi/model/SIGMETAIRMETBuilderHelper.java
@@ -1,0 +1,51 @@
+package fi.fmi.avi.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.BiConsumer;
+
+import fi.fmi.avi.model.immutable.AirspaceImpl;
+
+public final class SIGMETAIRMETBuilderHelper {
+    private SIGMETAIRMETBuilderHelper() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Copy properties declared in {@link SIGMETAIRMET} from provided {@code value} to {@code builder} using provided setters.
+     *
+     * <p>
+     * This method exists for completeness safety. Whenever the {@link SIGMETAIRMET} interface changes, applying changes here will enforce to
+     * conform to changes in all builders using this method. This ensures that changes will not get unnoticed in builder classes.
+     * </p>
+     *
+     * @param <T>
+     *         type of {@code value}
+     * @param <B>
+     *         type of {@code builder}
+     * @param builder
+     *         builder to copy properties to
+     * @param value
+     *         value object to copy properties from
+     * @param setSequenceNumber
+     *         setter for sequenceNumber
+     * @param setValidityPeriod
+     *         setter for validityPeriod
+     * @param setAirspace
+     *         setter for airspace
+     * @param setStatus
+     *         setter for status
+     */
+    public static <T extends SIGMETAIRMET, B> void copyFrom(final B builder, final T value,  //
+            final BiConsumer<B, String> setSequenceNumber, //
+            final BiConsumer<B, PartialOrCompleteTimePeriod> setValidityPeriod, //
+            final BiConsumer<B, Airspace> setAirspace, //
+            final BiConsumer<B, AviationCodeListUser.SigmetAirmetReportStatus> setStatus) {
+        requireNonNull(value, "value");
+        requireNonNull(builder, "builder");
+        setSequenceNumber.accept(builder, value.getSequenceNumber());
+        setValidityPeriod.accept(builder, value.getValidityPeriod());
+        setAirspace.accept(builder, AirspaceImpl.immutableCopyOf(value.getAirspace()));
+        setStatus.accept(builder, value.getStatus());
+    }
+}

--- a/src/main/java/fi/fmi/avi/model/SIGMETAIRMETBuilderHelper.java
+++ b/src/main/java/fi/fmi/avi/model/SIGMETAIRMETBuilderHelper.java
@@ -33,19 +33,19 @@ public final class SIGMETAIRMETBuilderHelper {
      *         setter for validityPeriod
      * @param setAirspace
      *         setter for airspace
-     * @param setStatus
-     *         setter for status
+     * @param setCancelMessage
+     *         setter for cancelMessage
      */
     public static <T extends SIGMETAIRMET, B> void copyFrom(final B builder, final T value,  //
             final BiConsumer<B, String> setSequenceNumber, //
             final BiConsumer<B, PartialOrCompleteTimePeriod> setValidityPeriod, //
             final BiConsumer<B, Airspace> setAirspace, //
-            final BiConsumer<B, AviationCodeListUser.SigmetAirmetReportStatus> setStatus) {
+            final BiConsumer<B, Boolean> setCancelMessage) {
         requireNonNull(value, "value");
         requireNonNull(builder, "builder");
         setSequenceNumber.accept(builder, value.getSequenceNumber());
         setValidityPeriod.accept(builder, value.getValidityPeriod());
         setAirspace.accept(builder, AirspaceImpl.immutableCopyOf(value.getAirspace()));
-        setStatus.accept(builder, value.getStatus());
+        setCancelMessage.accept(builder, value.isCancelMessage());
     }
 }

--- a/src/main/java/fi/fmi/avi/model/bulletin/MeteorologicalBulletinBuilderHelper.java
+++ b/src/main/java/fi/fmi/avi/model/bulletin/MeteorologicalBulletinBuilderHelper.java
@@ -1,0 +1,62 @@
+package fi.fmi.avi.model.bulletin;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import fi.fmi.avi.model.AviationWeatherMessage;
+import fi.fmi.avi.model.bulletin.immutable.BulletinHeadingImpl;
+
+public final class MeteorologicalBulletinBuilderHelper {
+    private MeteorologicalBulletinBuilderHelper() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Copy properties declared in {@link MeteorologicalBulletin} from provided {@code value} to {@code builder} using provided setters.
+     *
+     * <p>
+     * This method exists for completeness safety. Whenever the {@link MeteorologicalBulletin} interface changes, applying changes here will enforce to
+     * conform to changes in all builders using this method. This ensures that changes will not get unnoticed in builder classes.
+     * </p>
+     *
+     * @param <T>
+     *         type of {@code value}
+     * @param <B>
+     *         type of {@code builder}
+     * @param builder
+     *         builder to copy properties to
+     * @param value
+     *         value object to copy properties from
+     * @param setHeading
+     *         setter for heading
+     * @param addAllMessages
+     *         setter for messages
+     * @param toImmutableMessage
+     *         function transforming message to immutable
+     * @param setTimeStamp
+     *         setter for timeStamp
+     * @param addAllTimeStampFields
+     *         setter for timeStampFields
+     */
+    public static <T extends MeteorologicalBulletin<M>, M extends AviationWeatherMessage, B> void copyFrom(final B builder, final T value,  //
+            final BiConsumer<B, BulletinHeading> setHeading, //
+            final BiConsumer<B, Stream<M>> addAllMessages, //
+            final Function<M, ? extends M> toImmutableMessage, //
+            final BiConsumer<B, Optional<ZonedDateTime>> setTimeStamp, //
+            final BiConsumer<B, Set<ChronoField>> addAllTimeStampFields) {
+        requireNonNull(value, "value");
+        requireNonNull(builder, "builder");
+        setHeading.accept(builder, BulletinHeadingImpl.immutableCopyOf(value.getHeading()));
+        addAllMessages.accept(builder, value.getMessages().stream().map(toImmutableMessage));
+        setTimeStamp.accept(builder, value.getTimeStamp());
+        addAllTimeStampFields.accept(builder, value.getTimeStampFields());
+    }
+
+}

--- a/src/main/java/fi/fmi/avi/model/bulletin/immutable/GenericMeteorologicalBulletinImpl.java
+++ b/src/main/java/fi/fmi/avi/model/bulletin/immutable/GenericMeteorologicalBulletinImpl.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import fi.fmi.avi.model.GenericAviationWeatherMessage;
 import fi.fmi.avi.model.bulletin.BulletinHeading;
 import fi.fmi.avi.model.bulletin.GenericMeteorologicalBulletin;
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinBuilderHelper;
 import fi.fmi.avi.model.immutable.GenericAviationWeatherMessageImpl;
 
 @FreeBuilder
@@ -53,10 +54,14 @@ public abstract class GenericMeteorologicalBulletinImpl implements GenericMeteor
             if (value instanceof GenericMeteorologicalBulletinImpl) {
                 return ((GenericMeteorologicalBulletinImpl) value).toBuilder();
             } else {
-                return builder()//
-                        .setHeading(BulletinHeadingImpl.immutableCopyOf(value.getHeading()))//
-                        .setTimeStamp(value.getTimeStamp()).addAllMessages(value.getMessages()).addAllTimeStampFields(value.getTimeStampFields());
-
+                final Builder builder = builder();
+                MeteorologicalBulletinBuilderHelper.copyFrom(builder, value, //
+                        Builder::setHeading, //
+                        Builder::addAllMessages, //
+                        GenericAviationWeatherMessageImpl::immutableCopyOf, //
+                        Builder::setTimeStamp, //
+                        Builder::addAllTimeStampFields);
+                return builder;
             }
         }
 

--- a/src/main/java/fi/fmi/avi/model/immutable/GenericAviationWeatherMessageImpl.java
+++ b/src/main/java/fi/fmi/avi/model/immutable/GenericAviationWeatherMessageImpl.java
@@ -1,7 +1,6 @@
 package fi.fmi.avi.model.immutable;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -13,16 +12,20 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import fi.fmi.avi.model.Aerodrome;
+import fi.fmi.avi.model.AviationWeatherMessageBuilderHelper;
 import fi.fmi.avi.model.GenericAviationWeatherMessage;
 
 @FreeBuilder
 @JsonDeserialize(builder = GenericAviationWeatherMessageImpl.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({ "messageType", "messageFormat", "originalMessage",
-        "issueTime", "validityTime", "targetAerodrome"})
+@JsonPropertyOrder({ "messageType", "messageFormat", "originalMessage", "issueTime", "validityTime", "targetAerodrome" })
 public abstract class GenericAviationWeatherMessageImpl implements GenericAviationWeatherMessage, Serializable {
 
     private static final long serialVersionUID = 2232603779482075673L;
+
+    public static Builder builder() {
+        return new Builder();
+    }
 
     public static GenericAviationWeatherMessageImpl immutableCopyOf(final GenericAviationWeatherMessage message) {
         Objects.requireNonNull(message);
@@ -50,43 +53,41 @@ public abstract class GenericAviationWeatherMessageImpl implements GenericAviati
             }
         }
         if (this.getValidityTime().isPresent()) {
-            if (!this.getValidityTime().get().isComplete()) {
-                return false;
-            }
+            return this.getValidityTime().get().isComplete();
         }
         return true;
     }
 
-
     public static class Builder extends GenericAviationWeatherMessageImpl_Builder {
+        @Deprecated
+        public Builder() {
+        }
 
         public static Builder from(final GenericAviationWeatherMessage value) {
             if (value instanceof GenericAviationWeatherMessageImpl) {
                 return ((GenericAviationWeatherMessageImpl) value).toBuilder();
             } else {
-                //From AviationWeatherMessage:
-                final GenericAviationWeatherMessageImpl.Builder retval = new GenericAviationWeatherMessageImpl.Builder()//
-                        .setPermissibleUsage(value.getPermissibleUsage())//
-                        .setPermissibleUsageReason(value.getPermissibleUsageReason())//
-                        .setPermissibleUsageSupplementary(value.getPermissibleUsageSupplementary())//
-                        .setTranslated(value.isTranslated())//
-                        .setTranslatedBulletinID(value.getTranslatedBulletinID())//
-                        .setTranslatedBulletinReceptionTime(value.getTranslatedBulletinReceptionTime())//
-                        .setTranslationCentreDesignator(value.getTranslationCentreDesignator())//
-                        .setTranslationCentreName(value.getTranslationCentreName())//
-                        .setTranslationTime(value.getTranslationTime())//
-                        .setTranslatedTAC(value.getTranslatedTAC());
-
-                value.getRemarks().map(remarks -> retval.setRemarks(Collections.unmodifiableList(remarks)));
-
-                retval.setOriginalMessage(value.getOriginalMessage())
+                final Builder builder = builder();
+                AviationWeatherMessageBuilderHelper.copyFrom(builder, value,  //
+                        Builder::setRemarks, //
+                        Builder::setPermissibleUsage, //
+                        Builder::setPermissibleUsageReason, //
+                        Builder::setPermissibleUsageSupplementary, //
+                        Builder::setTranslated, //
+                        Builder::setTranslatedBulletinID, //
+                        Builder::setTranslatedBulletinReceptionTime, //
+                        Builder::setTranslationCentreDesignator, //
+                        Builder::setTranslationCentreName, //
+                        Builder::setTranslationTime, //
+                        Builder::setTranslatedTAC, //
+                        Builder::setIssueTime, //
+                        Builder::setReportStatus);
+                return builder//
+                        .setOriginalMessage(value.getOriginalMessage())//
                         .setMessageType(value.getMessageType())//
                         .setMessageFormat(value.getMessageFormat())//
-                        .setIssueTime(value.getIssueTime())//
                         .setValidityTime(value.getValidityTime())//
                         .setTargetAerodrome(value.getTargetAerodrome());
-
-                return retval;
             }
         }
 

--- a/src/main/java/fi/fmi/avi/model/immutable/GenericAviationWeatherMessageImpl.java
+++ b/src/main/java/fi/fmi/avi/model/immutable/GenericAviationWeatherMessageImpl.java
@@ -69,7 +69,9 @@ public abstract class GenericAviationWeatherMessageImpl implements GenericAviati
                 return ((GenericAviationWeatherMessageImpl) value).toBuilder();
             } else {
                 final Builder builder = builder();
-                AviationWeatherMessageBuilderHelper.copyFrom(builder, value,  //
+                AviationWeatherMessageBuilderHelper.copyFrom(builder, value, //
+                        Builder::setReportStatus, //
+                        Builder::setIssueTime, //
                         Builder::setRemarks, //
                         Builder::setPermissibleUsage, //
                         Builder::setPermissibleUsageReason, //
@@ -80,9 +82,7 @@ public abstract class GenericAviationWeatherMessageImpl implements GenericAviati
                         Builder::setTranslationCentreDesignator, //
                         Builder::setTranslationCentreName, //
                         Builder::setTranslationTime, //
-                        Builder::setTranslatedTAC, //
-                        Builder::setIssueTime, //
-                        Builder::setReportStatus);
+                        Builder::setTranslatedTAC);
                 return builder//
                         .setOriginalMessage(value.getOriginalMessage())//
                         .setMessageType(value.getMessageType())//

--- a/src/main/java/fi/fmi/avi/model/immutable/GenericAviationWeatherMessageImpl.java
+++ b/src/main/java/fi/fmi/avi/model/immutable/GenericAviationWeatherMessageImpl.java
@@ -61,6 +61,7 @@ public abstract class GenericAviationWeatherMessageImpl implements GenericAviati
     public static class Builder extends GenericAviationWeatherMessageImpl_Builder {
         @Deprecated
         public Builder() {
+            setReportStatus(ReportStatus.NORMAL);
         }
 
         public static Builder from(final GenericAviationWeatherMessage value) {

--- a/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReport.java
+++ b/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReport.java
@@ -18,7 +18,7 @@ public interface MeteorologicalTerminalAirReport extends AerodromeWeatherMessage
 
     @Deprecated
     default MetarStatus getStatus() {
-        return MetarStatus.fromReportStatus(getReportStatus().orElse(ReportStatus.NORMAL), isMissingMessage());
+        return MetarStatus.fromReportStatus(getReportStatus(), isMissingMessage());
     }
 
     boolean isMissingMessage();

--- a/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReport.java
+++ b/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReport.java
@@ -16,7 +16,12 @@ public interface MeteorologicalTerminalAirReport extends AerodromeWeatherMessage
 
     boolean isAutomatedStation();
 
-    MetarStatus getStatus();
+    @Deprecated
+    default MetarStatus getStatus() {
+        return MetarStatus.fromReportStatus(getReportStatus().orElse(ReportStatus.NORMAL), isMissingMessage());
+    }
+
+    boolean isMissingMessage();
 
     boolean isCeilingAndVisibilityOk();
 

--- a/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReportBuilder.java
+++ b/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReportBuilder.java
@@ -759,45 +759,22 @@ public interface MeteorologicalTerminalAirReportBuilder<T extends Meteorological
     B setIssueTime(Optional<? extends PartialOrCompleteTimeInstant> issueTime);
 
     /**
-     * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getReportStatus()}.
-     *
-     * @return this {@code Builder} object
-     */
-    default B setNullableReportStatus(final AviationWeatherMessage.ReportStatus reportStatus) {
-        if (reportStatus != null) {
-            return setReportStatus(reportStatus);
-        } else {
-            return clearReportStatus();
-        }
-    }
-
-    /**
-     * If the value to be returned by {@link MeteorologicalTerminalAirReport#getReportStatus()} is present, replaces it by
-     * applying {@code mapper} to it and using the result.
-     *
-     * <p>If the result is null, clears the value.
+     * Replaces the value to be returned by {@link MeteorologicalTerminalAirReport#getReportStatus()} by applying {@code
+     * mapper} to it and using the result.
      *
      * @return this {@code Builder} object
      *
      * @throws NullPointerException
-     *         if {@code mapper} is null
+     *         if {@code mapper} is null or returns null
      */
     default B mapReportStatus(final UnaryOperator<AviationWeatherMessage.ReportStatus> mapper) {
-        return setReportStatus(getReportStatus().map(mapper));
+        return setReportStatus(mapper.apply(getReportStatus()));
     }
-
-    /**
-     * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getReportStatus()} to {@link Optional#empty()
-     * Optional.empty()}.
-     *
-     * @return this {@code Builder} object
-     */
-    B clearReportStatus();
 
     /**
      * Returns the value that will be returned by {@link MeteorologicalTerminalAirReport#getReportStatus()}.
      */
-    Optional<AviationWeatherMessage.ReportStatus> getReportStatus();
+    AviationWeatherMessage.ReportStatus getReportStatus();
 
     /**
      * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getReportStatus()}.
@@ -808,19 +785,6 @@ public interface MeteorologicalTerminalAirReportBuilder<T extends Meteorological
      *         if {@code reportStatus} is null
      */
     B setReportStatus(AviationWeatherMessage.ReportStatus reportStatus);
-
-    /**
-     * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getReportStatus()}.
-     *
-     * @return this {@code Builder} object
-     */
-    default B setReportStatus(final Optional<? extends AviationWeatherMessage.ReportStatus> reportStatus) {
-        if (reportStatus.isPresent()) {
-            return setReportStatus(reportStatus.get());
-        } else {
-            return clearReportStatus();
-        }
-    }
 
     /**
      * Replaces the value to be returned by {@link MeteorologicalTerminalAirReport#getAerodrome()} by applying {@code
@@ -917,7 +881,7 @@ public interface MeteorologicalTerminalAirReportBuilder<T extends Meteorological
      */
     @Deprecated
     default AviationCodeListUser.MetarStatus getStatus() {
-        return AviationCodeListUser.MetarStatus.fromReportStatus(getReportStatus().orElse(AviationWeatherMessage.ReportStatus.NORMAL), isMissingMessage());
+        return AviationCodeListUser.MetarStatus.fromReportStatus(getReportStatus(), isMissingMessage());
     }
 
     /**

--- a/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReportBuilder.java
+++ b/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReportBuilder.java
@@ -15,6 +15,7 @@ import javax.annotation.Nullable;
 
 import fi.fmi.avi.model.Aerodrome;
 import fi.fmi.avi.model.AviationCodeListUser;
+import fi.fmi.avi.model.AviationWeatherMessage;
 import fi.fmi.avi.model.NumericMeasure;
 import fi.fmi.avi.model.PartialOrCompleteTimeInstant;
 import fi.fmi.avi.model.Weather;
@@ -702,6 +703,48 @@ public interface MeteorologicalTerminalAirReportBuilder<T extends Meteorological
      * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getIssueTime()}.
      *
      * @return this {@code Builder} object
+     */
+    default B setNullableIssueTime(@Nullable final PartialOrCompleteTimeInstant issueTime) {
+        if (issueTime != null) {
+            return setIssueTime(issueTime);
+        } else {
+            return clearIssueTime();
+        }
+    }
+
+    /**
+     * If the value to be returned by {@link MeteorologicalTerminalAirReport#getIssueTime()} is present, replaces it by
+     * applying {@code mapper} to it and using the result.
+     *
+     * <p>If the result is null, clears the value.
+     *
+     * @return this {@code Builder} object
+     *
+     * @throws NullPointerException
+     *         if {@code mapper} is null
+     */
+    default B mapIssueTime(final UnaryOperator<PartialOrCompleteTimeInstant> mapper) {
+        Objects.requireNonNull(mapper);
+        return setIssueTime(getIssueTime().map(mapper));
+    }
+
+    /**
+     * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getIssueTime()} to {@link Optional#empty()
+     * Optional.empty()}.
+     *
+     * @return this {@code Builder} object
+     */
+    B clearIssueTime();
+
+    /**
+     * Returns the value that will be returned by {@link MeteorologicalTerminalAirReport#getIssueTime()}.
+     */
+    Optional<PartialOrCompleteTimeInstant> getIssueTime();
+
+    /**
+     * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getIssueTime()}.
+     *
+     * @return this {@code Builder} object
      *
      * @throws NullPointerException
      *         if {@code issueTime} is null
@@ -716,46 +759,68 @@ public interface MeteorologicalTerminalAirReportBuilder<T extends Meteorological
     B setIssueTime(Optional<? extends PartialOrCompleteTimeInstant> issueTime);
 
     /**
-     * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getIssueTime()}.
+     * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getReportStatus()}.
      *
      * @return this {@code Builder} object
      */
-    default B setNullableIssueTime(@Nullable PartialOrCompleteTimeInstant issueTime){
-        if (issueTime != null) {
-            return setIssueTime(issueTime);
+    default B setNullableReportStatus(final AviationWeatherMessage.ReportStatus reportStatus) {
+        if (reportStatus != null) {
+            return setReportStatus(reportStatus);
         } else {
-            return clearIssueTime();
+            return clearReportStatus();
         }
     }
 
-
     /**
-     * If the value to be returned by {@link MeteorologicalTerminalAirReport#getIssueTime()} is present, replaces it by
+     * If the value to be returned by {@link MeteorologicalTerminalAirReport#getReportStatus()} is present, replaces it by
      * applying {@code mapper} to it and using the result.
      *
      * <p>If the result is null, clears the value.
      *
      * @return this {@code Builder} object
-     * @throws NullPointerException if {@code mapper} is null
+     *
+     * @throws NullPointerException
+     *         if {@code mapper} is null
      */
-    default B mapIssueTime(UnaryOperator<PartialOrCompleteTimeInstant> mapper){
-        Objects.requireNonNull(mapper);
-        return setIssueTime(getIssueTime().map(mapper));
+    default B mapReportStatus(final UnaryOperator<AviationWeatherMessage.ReportStatus> mapper) {
+        return setReportStatus(getReportStatus().map(mapper));
     }
 
     /**
-     * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getIssueTime()} to {@link Optional#empty()
+     * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getReportStatus()} to {@link Optional#empty()
      * Optional.empty()}.
      *
      * @return this {@code Builder} object
      */
-    B clearIssueTime();
-
+    B clearReportStatus();
 
     /**
-     * Returns the value that will be returned by {@link MeteorologicalTerminalAirReport#getIssueTime()}.
+     * Returns the value that will be returned by {@link MeteorologicalTerminalAirReport#getReportStatus()}.
      */
-    Optional<PartialOrCompleteTimeInstant> getIssueTime();
+    Optional<AviationWeatherMessage.ReportStatus> getReportStatus();
+
+    /**
+     * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getReportStatus()}.
+     *
+     * @return this {@code Builder} object
+     *
+     * @throws NullPointerException
+     *         if {@code reportStatus} is null
+     */
+    B setReportStatus(AviationWeatherMessage.ReportStatus reportStatus);
+
+    /**
+     * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getReportStatus()}.
+     *
+     * @return this {@code Builder} object
+     */
+    default B setReportStatus(final Optional<? extends AviationWeatherMessage.ReportStatus> reportStatus) {
+        if (reportStatus.isPresent()) {
+            return setReportStatus(reportStatus.get());
+        } else {
+            return clearReportStatus();
+        }
+    }
 
     /**
      * Replaces the value to be returned by {@link MeteorologicalTerminalAirReport#getAerodrome()} by applying {@code

--- a/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReportBuilder.java
+++ b/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReportBuilder.java
@@ -898,28 +898,97 @@ public interface MeteorologicalTerminalAirReportBuilder<T extends Meteorological
      * @throws IllegalStateException
      *         if the field has not been set
      */
+    @Deprecated
     default B mapStatus(final UnaryOperator<AviationCodeListUser.MetarStatus> mapper) {
         Objects.requireNonNull(mapper);
         return setStatus(mapper.apply(getStatus()));
     }
 
     /**
-     * Returns the value that will be returned by {@link MeteorologicalTerminalAirReport#getStatus()}.
+     * Provides the current builder value of the status property.
      *
-     * @throws IllegalStateException
-     *         if the field has not been set
+     * Note, this method is provided for backward compatibility with previous versions of the API. The <code>status</code> is no longer
+     * explicitly stored. This implementation uses {@link AviationCodeListUser.MetarStatus#fromReportStatus(AviationWeatherMessage.ReportStatus, boolean)}
+     * instead to determine the returned value on-the-fly.
+     *
+     * @return the message status
+     *
+     * @deprecated migrate to using a combination of {@link #getReportStatus()} and {@link #isMissingMessage()} instead
      */
-    AviationCodeListUser.MetarStatus getStatus();
+    @Deprecated
+    default AviationCodeListUser.MetarStatus getStatus() {
+        return AviationCodeListUser.MetarStatus.fromReportStatus(getReportStatus().orElse(AviationWeatherMessage.ReportStatus.NORMAL), isMissingMessage());
+    }
 
     /**
-     * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#getStatus()}.
+     * Sets the METAR-specific message status.
+     *
+     * Note, this method is provided for backward compatibility with previous versions of the API. The <code>status</code> is no longer
+     * explicitly stored. Instead, this method sets other property values with the following logic:
+     * <dl>
+     *     <dt>{@link fi.fmi.avi.model.AviationCodeListUser.MetarStatus#MISSING MISSING}</dt>
+     *     <dd>
+     *         <code>reportStatus = {@link fi.fmi.avi.model.AviationWeatherMessage.ReportStatus#NORMAL NORMAL}</code><br>
+     *         <code>missingMessage = {@code true}</code>
+     *     </dd>
+     *
+     *     <dt>{@link fi.fmi.avi.model.AviationCodeListUser.MetarStatus#NORMAL NORMAL}</dt>
+     *     <dd>
+     *         <code>reportStatus = {@link fi.fmi.avi.model.AviationWeatherMessage.ReportStatus#NORMAL NORMAL}</code><br>
+     *         <code>missingMessage = {@code false}</code>
+     *     </dd>
+     *
+     *     <dt>{@link fi.fmi.avi.model.AviationCodeListUser.MetarStatus#CORRECTION CORRECTION}</dt>
+     *     <dd>
+     *         <code>reportStatus = {@link fi.fmi.avi.model.AviationWeatherMessage.ReportStatus#CORRECTION CORRECTION}</code><br>
+     *         <code>missingMessage = {@code false}</code>
+     *     </dd>
+     * </dl>
+     *
+     * @param status
+     *         the status to set
+     *
+     * @return builder
+     *
+     * @deprecated migrate to using a combination of {@link #setReportStatus(AviationWeatherMessage.ReportStatus)} and {@link #setMissingMessage(boolean)}.
+     */
+    @Deprecated
+    default B setStatus(final AviationCodeListUser.MetarStatus status) {
+        requireNonNull(status);
+        return setMissingMessage(status.isMissingMessage())//
+                .setReportStatus(status.getReportStatus());
+    }
+
+    /**
+     * Replaces the value to be returned by {@link MeteorologicalTerminalAirReport#isMissingMessage()} by applying
+     * {@code mapper} to it and using the result.
      *
      * @return this {@code Builder} object
      *
      * @throws NullPointerException
-     *         if {@code status} is null
+     *         if {@code mapper} is null or returns null
+     * @throws IllegalStateException
+     *         if the field has not been set
      */
-    B setStatus(AviationCodeListUser.MetarStatus status);
+    default B mapMissingMessage(final UnaryOperator<Boolean> mapper) {
+        Objects.requireNonNull(mapper);
+        return setMissingMessage(mapper.apply(isMissingMessage()));
+    }
+
+    /**
+     * Returns the value that will be returned by {@link MeteorologicalTerminalAirReport#isMissingMessage()}.
+     *
+     * @throws IllegalStateException
+     *         if the field has not been set
+     */
+    boolean isMissingMessage();
+
+    /**
+     * Sets the value to be returned by {@link MeteorologicalTerminalAirReport#isMissingMessage()}.
+     *
+     * @return this {@code Builder} object
+     */
+    B setMissingMessage(boolean missingMessage);
 
     /**
      * Replaces the value to be returned by {@link MeteorologicalTerminalAirReport#isCeilingAndVisibilityOk()} by

--- a/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReportBuilderHelper.java
+++ b/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReportBuilderHelper.java
@@ -57,7 +57,7 @@ public final class MeteorologicalTerminalAirReportBuilderHelper {
                 MeteorologicalTerminalAirReportBuilder::setAerodrome);
         builder//
                 .setAutomatedStation(value.isAutomatedStation())//
-                .setStatus(value.getStatus())//
+                .setMissingMessage(value.isMissingMessage())//
                 .setCeilingAndVisibilityOk(value.isCeilingAndVisibilityOk())//
                 .setAirTemperature(NumericMeasureImpl.immutableCopyOf(value.getAirTemperature()))//
                 .setDewpointTemperature(NumericMeasureImpl.immutableCopyOf(value.getDewpointTemperature()))//

--- a/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReportBuilderHelper.java
+++ b/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReportBuilderHelper.java
@@ -1,6 +1,6 @@
 package fi.fmi.avi.model.metar;
 
-import static fi.fmi.avi.model.taf.TAFForecastBuilderHelper.toImmutableList;
+import static fi.fmi.avi.model.BuilderHelper.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 import java.time.ZonedDateTime;
@@ -9,20 +9,23 @@ import java.util.Collections;
 import java.util.List;
 
 import fi.fmi.avi.model.Aerodrome;
+import fi.fmi.avi.model.AerodromeWeatherMessageBuilderHelper;
+import fi.fmi.avi.model.AviationWeatherMessageBuilderHelper;
 import fi.fmi.avi.model.PartialOrCompleteTime;
 import fi.fmi.avi.model.PartialOrCompleteTimeInstant;
 import fi.fmi.avi.model.PartialOrCompleteTimePeriod;
 import fi.fmi.avi.model.PartialOrCompleteTimes;
-import fi.fmi.avi.model.immutable.AerodromeImpl;
 import fi.fmi.avi.model.immutable.NumericMeasureImpl;
 import fi.fmi.avi.model.immutable.RunwayDirectionImpl;
 import fi.fmi.avi.model.immutable.WeatherImpl;
+import fi.fmi.avi.model.metar.immutable.HorizontalVisibilityImpl;
 import fi.fmi.avi.model.metar.immutable.ObservedCloudsImpl;
 import fi.fmi.avi.model.metar.immutable.ObservedSurfaceWindImpl;
 import fi.fmi.avi.model.metar.immutable.RunwayStateImpl;
 import fi.fmi.avi.model.metar.immutable.RunwayVisualRangeImpl;
 import fi.fmi.avi.model.metar.immutable.SeaStateImpl;
 import fi.fmi.avi.model.metar.immutable.TrendForecastImpl;
+import fi.fmi.avi.model.metar.immutable.WindShearImpl;
 
 /**
  * Helper methods for implementations of {@link MeteorologicalTerminalAirReportBuilder}.
@@ -36,41 +39,42 @@ public final class MeteorologicalTerminalAirReportBuilderHelper {
         requireNonNull(builder, "builder");
         requireNonNull(value, "value");
 
-        //From AviationWeatherMessage:
-        builder.setPermissibleUsage(value.getPermissibleUsage());
-        builder.setPermissibleUsageReason(value.getPermissibleUsageReason());
-        builder.setPermissibleUsageSupplementary(value.getPermissibleUsageSupplementary());
-        builder.setTranslated(value.isTranslated());
-        builder.setTranslatedBulletinID(value.getTranslatedBulletinID());
-        builder.setTranslatedBulletinReceptionTime(value.getTranslatedBulletinReceptionTime());
-        builder.setTranslationCentreDesignator(value.getTranslationCentreDesignator());
-        builder.setTranslationCentreName(value.getTranslationCentreName());
-        builder.setTranslationTime(value.getTranslationTime());
-        builder.setTranslatedTAC(value.getTranslatedTAC());
-        builder.setRemarks(value.getRemarks());
-
-        //From AerodromeWeatherMessage:
-        builder.setIssueTime(value.getIssueTime().map(issueTime -> PartialOrCompleteTimeInstant.Builder.from(issueTime).build()));
-        builder.setAerodrome(AerodromeImpl.immutableCopyOf(value.getAerodrome()));
-
-        //From MeteorologicalTerminalAirReport:
-        builder.setAutomatedStation(value.isAutomatedStation());
-        builder.setSnowClosure(value.isSnowClosure());
-        builder.setCeilingAndVisibilityOk(value.isCeilingAndVisibilityOk());
-        builder.setNoSignificantChanges(value.isNoSignificantChanges());
-        builder.setAirTemperature(NumericMeasureImpl.immutableCopyOf(value.getAirTemperature()));
-        builder.setAltimeterSettingQNH(NumericMeasureImpl.immutableCopyOf(value.getAltimeterSettingQNH()));
-        builder.setClouds(ObservedCloudsImpl.immutableCopyOf(value.getClouds()));
-        builder.setColorState(value.getColorState());
-        builder.setDewpointTemperature(NumericMeasureImpl.immutableCopyOf(value.getDewpointTemperature()));
-        builder.setPresentWeather(value.getPresentWeather().map(list -> toImmutableList(list, WeatherImpl::immutableCopyOf)));
-        builder.setRecentWeather(value.getRecentWeather().map(list -> toImmutableList(list, WeatherImpl::immutableCopyOf)));
-        builder.setRunwayStates(value.getRunwayStates().map(list -> toImmutableList(list, RunwayStateImpl::immutableCopyOf)));
-        builder.setRunwayVisualRanges(value.getRunwayVisualRanges().map(list -> toImmutableList(list, RunwayVisualRangeImpl::immutableCopyOf)));
-        builder.setSeaState(SeaStateImpl.immutableCopyOf(value.getSeaState()));
-        builder.setSurfaceWind(ObservedSurfaceWindImpl.immutableCopyOf(value.getSurfaceWind()));
-        builder.setStatus(value.getStatus());
-        builder.setTrends(value.getTrends().map(list -> toImmutableList(list, TrendForecastImpl::immutableCopyOf)));
+        AviationWeatherMessageBuilderHelper.copyFrom(builder, value,  //
+                MeteorologicalTerminalAirReportBuilder::setRemarks, //
+                MeteorologicalTerminalAirReportBuilder::setPermissibleUsage, //
+                MeteorologicalTerminalAirReportBuilder::setPermissibleUsageReason, //
+                MeteorologicalTerminalAirReportBuilder::setPermissibleUsageSupplementary, //
+                MeteorologicalTerminalAirReportBuilder::setTranslated, //
+                MeteorologicalTerminalAirReportBuilder::setTranslatedBulletinID, //
+                MeteorologicalTerminalAirReportBuilder::setTranslatedBulletinReceptionTime, //
+                MeteorologicalTerminalAirReportBuilder::setTranslationCentreDesignator, //
+                MeteorologicalTerminalAirReportBuilder::setTranslationCentreName, //
+                MeteorologicalTerminalAirReportBuilder::setTranslationTime, //
+                MeteorologicalTerminalAirReportBuilder::setTranslatedTAC, //
+                MeteorologicalTerminalAirReportBuilder::setIssueTime, //
+                MeteorologicalTerminalAirReportBuilder::setReportStatus);
+        AerodromeWeatherMessageBuilderHelper.copyFrom(builder, value,  //
+                MeteorologicalTerminalAirReportBuilder::setAerodrome);
+        builder//
+                .setAutomatedStation(value.isAutomatedStation())//
+                .setStatus(value.getStatus())//
+                .setCeilingAndVisibilityOk(value.isCeilingAndVisibilityOk())//
+                .setAirTemperature(NumericMeasureImpl.immutableCopyOf(value.getAirTemperature()))//
+                .setDewpointTemperature(NumericMeasureImpl.immutableCopyOf(value.getDewpointTemperature()))//
+                .setAltimeterSettingQNH(NumericMeasureImpl.immutableCopyOf(value.getAltimeterSettingQNH()))//
+                .setSurfaceWind(ObservedSurfaceWindImpl.immutableCopyOf(value.getSurfaceWind()))//
+                .setVisibility(HorizontalVisibilityImpl.immutableCopyOf(value.getVisibility()))//
+                .setRunwayVisualRanges(value.getRunwayVisualRanges().map(list -> toImmutableList(list, RunwayVisualRangeImpl::immutableCopyOf)))//
+                .setPresentWeather(value.getPresentWeather().map(list -> toImmutableList(list, WeatherImpl::immutableCopyOf)))//
+                .setClouds(ObservedCloudsImpl.immutableCopyOf(value.getClouds()))//
+                .setRecentWeather(value.getRecentWeather().map(list -> toImmutableList(list, WeatherImpl::immutableCopyOf)))//
+                .setWindShear(WindShearImpl.immutableCopyOf(value.getWindShear()))//
+                .setSeaState(SeaStateImpl.immutableCopyOf(value.getSeaState()))//
+                .setRunwayStates(value.getRunwayStates().map(list -> toImmutableList(list, RunwayStateImpl::immutableCopyOf)))//
+                .setSnowClosure(value.isSnowClosure())//
+                .setNoSignificantChanges(value.isNoSignificantChanges())//
+                .setTrends(value.getTrends().map(list -> toImmutableList(list, TrendForecastImpl::immutableCopyOf)))//
+                .setColorState(value.getColorState());
     }
 
     public static void afterSetAerodrome(final MeteorologicalTerminalAirReportBuilder<?, ?> builder, final Aerodrome aerodrome) {

--- a/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReportBuilderHelper.java
+++ b/src/main/java/fi/fmi/avi/model/metar/MeteorologicalTerminalAirReportBuilderHelper.java
@@ -39,7 +39,9 @@ public final class MeteorologicalTerminalAirReportBuilderHelper {
         requireNonNull(builder, "builder");
         requireNonNull(value, "value");
 
-        AviationWeatherMessageBuilderHelper.copyFrom(builder, value,  //
+        AviationWeatherMessageBuilderHelper.copyFrom(builder, value, //
+                MeteorologicalTerminalAirReportBuilder::setReportStatus, //
+                MeteorologicalTerminalAirReportBuilder::setIssueTime, //
                 MeteorologicalTerminalAirReportBuilder::setRemarks, //
                 MeteorologicalTerminalAirReportBuilder::setPermissibleUsage, //
                 MeteorologicalTerminalAirReportBuilder::setPermissibleUsageReason, //
@@ -50,9 +52,7 @@ public final class MeteorologicalTerminalAirReportBuilderHelper {
                 MeteorologicalTerminalAirReportBuilder::setTranslationCentreDesignator, //
                 MeteorologicalTerminalAirReportBuilder::setTranslationCentreName, //
                 MeteorologicalTerminalAirReportBuilder::setTranslationTime, //
-                MeteorologicalTerminalAirReportBuilder::setTranslatedTAC, //
-                MeteorologicalTerminalAirReportBuilder::setIssueTime, //
-                MeteorologicalTerminalAirReportBuilder::setReportStatus);
+                MeteorologicalTerminalAirReportBuilder::setTranslatedTAC);
         AerodromeWeatherMessageBuilderHelper.copyFrom(builder, value,  //
                 MeteorologicalTerminalAirReportBuilder::setAerodrome);
         builder//

--- a/src/main/java/fi/fmi/avi/model/metar/immutable/AbstractMeteorologicalTerminalAirReportImpl.java
+++ b/src/main/java/fi/fmi/avi/model/metar/immutable/AbstractMeteorologicalTerminalAirReportImpl.java
@@ -9,6 +9,12 @@ import fi.fmi.avi.model.metar.RunwayVisualRange;
 import fi.fmi.avi.model.metar.TrendForecast;
 
 public abstract class AbstractMeteorologicalTerminalAirReportImpl implements MeteorologicalTerminalAirReport {
+    @Override
+    @JsonIgnore
+    @Deprecated
+    public MetarStatus getStatus() {
+        return MeteorologicalTerminalAirReport.super.getStatus();
+    }
 
     /**
      * Returns true if issue time, valid time and all other time references contained in this

--- a/src/main/java/fi/fmi/avi/model/metar/immutable/METARImpl.java
+++ b/src/main/java/fi/fmi/avi/model/metar/immutable/METARImpl.java
@@ -35,9 +35,9 @@ import fi.fmi.avi.model.metar.WindShear;
 @FreeBuilder
 @JsonDeserialize(builder = METARImpl.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({ "status", "aerodrome", "issueTime", "automatedStation", "surfaceWind", "visibility", "runwayVisualRanges", "presentWeather", "cloud",
-        "airTemperature", "dewpointTemperature", "altimeterSettingQNH", "recentWeather", "windShear", "seaState", "runwayStates", "snowClosure",
-        "noSignificantChanges", "trend", "remarks", "permissibleUsage", "permissibleUsageReason", "permissibleUsageSupplementary", "translated",
+@JsonPropertyOrder({ "reportStatus", "missingMessage", "aerodrome", "issueTime", "automatedStation", "surfaceWind", "visibility", "runwayVisualRanges",
+        "presentWeather", "cloud", "airTemperature", "dewpointTemperature", "altimeterSettingQNH", "recentWeather", "windShear", "seaState", "runwayStates",
+        "snowClosure", "noSignificantChanges", "trend", "remarks", "permissibleUsage", "permissibleUsageReason", "permissibleUsageSupplementary", "translated",
         "translatedBulletinID", "translatedBulletinReceptionTime", "translationCentreDesignator", "translationCentreName", "translationTime", "translatedTAC" })
 public abstract class METARImpl extends AbstractMeteorologicalTerminalAirReportImpl implements METAR, Serializable {
 
@@ -70,6 +70,8 @@ public abstract class METARImpl extends AbstractMeteorologicalTerminalAirReportI
         @Deprecated
         public Builder() {
             setTranslated(false);
+            setReportStatus(ReportStatus.NORMAL);
+            setMissingMessage(false);
             setAutomatedStation(false);
             setCeilingAndVisibilityOk(false);
             setRoutineDelayed(false);

--- a/src/main/java/fi/fmi/avi/model/metar/immutable/SPECIImpl.java
+++ b/src/main/java/fi/fmi/avi/model/metar/immutable/SPECIImpl.java
@@ -35,9 +35,9 @@ import fi.fmi.avi.model.metar.WindShear;
 @FreeBuilder
 @JsonDeserialize(builder = SPECIImpl.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({ "status", "aerodrome", "issueTime", "automatedStation", "surfaceWind", "visibility", "runwayVisualRanges", "presentWeather", "cloud",
-        "airTemperature", "dewpointTemperature", "altimeterSettingQNH", "recentWeather", "windShear", "seaState", "runwayStates", "snowClosure",
-        "noSignificantChanges", "trend", "remarks", "permissibleUsage", "permissibleUsageReason", "permissibleUsageSupplementary", "translated",
+@JsonPropertyOrder({ "reportStatus", "missingMessage", "aerodrome", "issueTime", "automatedStation", "surfaceWind", "visibility", "runwayVisualRanges",
+        "presentWeather", "cloud", "airTemperature", "dewpointTemperature", "altimeterSettingQNH", "recentWeather", "windShear", "seaState", "runwayStates",
+        "snowClosure", "noSignificantChanges", "trend", "remarks", "permissibleUsage", "permissibleUsageReason", "permissibleUsageSupplementary", "translated",
         "translatedBulletinID", "translatedBulletinReceptionTime", "translationCentreDesignator", "translationCentreName", "translationTime", "translatedTAC" })
 public abstract class SPECIImpl extends AbstractMeteorologicalTerminalAirReportImpl implements SPECI, Serializable {
     private static final long serialVersionUID = 1918131429312289735L;
@@ -69,6 +69,8 @@ public abstract class SPECIImpl extends AbstractMeteorologicalTerminalAirReportI
         @Deprecated
         public Builder() {
             setTranslated(false);
+            setReportStatus(ReportStatus.NORMAL);
+            setMissingMessage(false);
             setAutomatedStation(false);
             setCeilingAndVisibilityOk(false);
             setSnowClosure(false);

--- a/src/main/java/fi/fmi/avi/model/sigmet/immutable/AIRMETImpl.java
+++ b/src/main/java/fi/fmi/avi/model/sigmet/immutable/AIRMETImpl.java
@@ -224,7 +224,7 @@ public abstract class AIRMETImpl implements AIRMET, Serializable {
          */
         @Deprecated
         public SigmetAirmetReportStatus getStatus() {
-            return SigmetAirmetReportStatus.fromReportStatus(getReportStatus().orElse(ReportStatus.NORMAL), isCancelMessage());
+            return SigmetAirmetReportStatus.fromReportStatus(getReportStatus(), isCancelMessage());
         }
 
         /**

--- a/src/main/java/fi/fmi/avi/model/sigmet/immutable/AIRMETImpl.java
+++ b/src/main/java/fi/fmi/avi/model/sigmet/immutable/AIRMETImpl.java
@@ -1,12 +1,9 @@
 package fi.fmi.avi.model.sigmet.immutable;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.inferred.freebuilder.FreeBuilder;
 
@@ -15,29 +12,35 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import fi.fmi.avi.model.AirTrafficServicesUnitWeatherMessageBuilderHelper;
 import fi.fmi.avi.model.Airspace;
+import fi.fmi.avi.model.AviationWeatherMessageBuilderHelper;
+import fi.fmi.avi.model.BuilderHelper;
 import fi.fmi.avi.model.NumericMeasure;
 import fi.fmi.avi.model.PartialOrCompleteTimeInstant;
-import fi.fmi.avi.model.immutable.PhenomenonGeometryWithHeightImpl;
+import fi.fmi.avi.model.PhenomenonGeometryWithHeight;
+import fi.fmi.avi.model.SIGMETAIRMETBuilderHelper;
 import fi.fmi.avi.model.UnitPropertyGroup;
 import fi.fmi.avi.model.immutable.AirspaceImpl;
 import fi.fmi.avi.model.immutable.NumericMeasureImpl;
+import fi.fmi.avi.model.immutable.PhenomenonGeometryWithHeightImpl;
 import fi.fmi.avi.model.immutable.UnitPropertyGroupImpl;
 import fi.fmi.avi.model.sigmet.AIRMET;
 import fi.fmi.avi.model.sigmet.AirmetCloudLevels;
 import fi.fmi.avi.model.sigmet.AirmetReference;
 import fi.fmi.avi.model.sigmet.AirmetWind;
-import fi.fmi.avi.model.PhenomenonGeometryWithHeight;
 
 @FreeBuilder
 @JsonDeserialize(builder = AIRMETImpl.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 @JsonPropertyOrder({ "status", "issuingAirTrafficServicesUnit", "meteorologicalWatchOffice", "sequenceNumber", "issueTime", "validityPeriod", "airspace",
-        "movingDirection", "movingSpeed",
-        "analysis",
-        "cancelledReport", "remarks", "permissibleUsage", "permissibleUsageReason", "permissibleUsageSupplementary", "translated",
-        "translatedBulletinID", "translatedBulletinReceptionTime", "translationCentreDesignator", "translationCentreName", "translationTime", "translatedTAC" })
+        "movingDirection", "movingSpeed", "analysis", "cancelledReport", "remarks", "permissibleUsage", "permissibleUsageReason",
+        "permissibleUsageSupplementary", "translated", "translatedBulletinID", "translatedBulletinReceptionTime", "translationCentreDesignator",
+        "translationCentreName", "translationTime", "translatedTAC" })
 public abstract class AIRMETImpl implements AIRMET, Serializable {
+    public static Builder builder() {
+        return new Builder();
+    }
 
     public static AIRMETImpl immutableCopyOf(final AIRMET airmet) {
         Objects.requireNonNull(airmet);
@@ -62,21 +65,19 @@ public abstract class AIRMETImpl implements AIRMET, Serializable {
             return false;
         }
         if (this.getAnalysisGeometries().isPresent()) {
-            for (PhenomenonGeometryWithHeight geometryWithHeight : this.getAnalysisGeometries().get()) {
+            for (final PhenomenonGeometryWithHeight geometryWithHeight : this.getAnalysisGeometries().get()) {
                 if (geometryWithHeight.getTime().isPresent() && !geometryWithHeight.getTime().get().getCompleteTime().isPresent()) {
                     return false;
                 }
             }
         }
 
-        if (this.getCancelledReference().isPresent() && (!this.getCancelledReference().get().getValidityPeriod().isComplete())) {
-            return false;
-        }
-        return true;
+        return !this.getCancelledReference().isPresent() || (this.getCancelledReference().get().getValidityPeriod().isComplete());
     }
 
     public static class Builder extends AIRMETImpl_Builder {
 
+        @Deprecated
         public Builder() {
             setTranslated(false);
         }
@@ -85,47 +86,44 @@ public abstract class AIRMETImpl implements AIRMET, Serializable {
             if (value instanceof AIRMETImpl) {
                 return ((AIRMETImpl) value).toBuilder();
             } else {
-                //From AviationWeatherMessage
-                Builder retval = new Builder()//
-                        .setIssueTime(value.getIssueTime())
-                        .setPermissibleUsage(value.getPermissibleUsage())
-                        .setPermissibleUsageReason(value.getPermissibleUsageReason())
-                        .setPermissibleUsageSupplementary(value.getPermissibleUsageSupplementary())
-                        .setTranslated(value.isTranslated())
-                        .setTranslatedBulletinID(value.getTranslatedBulletinID())
-                        .setTranslatedBulletinReceptionTime(value.getTranslatedBulletinReceptionTime())
-                        .setTranslationCentreDesignator(value.getTranslationCentreDesignator())
-                        .setTranslationCentreName(value.getTranslationCentreName())
-                        .setTranslationTime(value.getTranslationTime())
-                        .setTranslatedTAC(value.getTranslatedTAC());
-
-                value.getRemarks().map(remarks -> retval.setRemarks(Collections.unmodifiableList(new ArrayList<>(remarks))));
-
-                //From AirTrafficServicesUnitWeatherMessage
-                retval.setIssuingAirTrafficServicesUnit(UnitPropertyGroupImpl.immutableCopyOf(value.getIssuingAirTrafficServicesUnit()))
-                        .setMeteorologicalWatchOffice(UnitPropertyGroupImpl.immutableCopyOf(value.getMeteorologicalWatchOffice()));
-
-                //From AirmetSigmet
-                retval.setAirspace(AirspaceImpl.immutableCopyOf(value.getAirspace()));
-
-                retval.setVisibility(NumericMeasureImpl.immutableCopyOf(value.getVisibility()));
-                retval.setObscuration(value.getObscuration());
-                retval.setCloudLevels(AirmetCloudLevelsImpl.immutableCopyOf(value.getCloudLevels()));
-                retval.setWind(AirmetWindImpl.immutableCopyOf(value.getWind()));
-
-                //From Sigmet
-                retval.setStatus(value.getStatus())
-                        .setSequenceNumber(value.getSequenceNumber())
-                        .setValidityPeriod(value.getValidityPeriod())
-                        .setAirmetPhenomenon(value.getAirmetPhenomenon())
-                        .setMovingDirection(NumericMeasureImpl.immutableCopyOf(value.getMovingDirection()))
-                        .setMovingSpeed(NumericMeasureImpl.immutableCopyOf(value.getMovingSpeed()))
-                        .setCancelledReference(AirmetReferenceImpl.immutableCopyOf(value.getCancelledReference()));
-
-                value.getAnalysisGeometries().map(an -> retval.setAnalysisGeometries(
-                        (Collections.unmodifiableList(an.stream().map(PhenomenonGeometryWithHeightImpl::immutableCopyOf).collect(Collectors.toList())))));
-
-                return retval;
+                final Builder builder = builder();
+                AviationWeatherMessageBuilderHelper.copyFrom(builder, value,  //
+                        Builder::setRemarks, //
+                        Builder::setPermissibleUsage, //
+                        Builder::setPermissibleUsageReason, //
+                        Builder::setPermissibleUsageSupplementary, //
+                        Builder::setTranslated, //
+                        Builder::setTranslatedBulletinID, //
+                        Builder::setTranslatedBulletinReceptionTime, //
+                        Builder::setTranslationCentreDesignator, //
+                        Builder::setTranslationCentreName, //
+                        Builder::setTranslationTime, //
+                        Builder::setTranslatedTAC, //
+                        Builder::setIssueTime, //
+                        Builder::setReportStatus);
+                AirTrafficServicesUnitWeatherMessageBuilderHelper.copyFrom(builder, value, //
+                        Builder::setIssuingAirTrafficServicesUnit, //
+                        Builder::setMeteorologicalWatchOffice);
+                SIGMETAIRMETBuilderHelper.copyFrom(builder, value, //
+                        Builder::setSequenceNumber, //
+                        Builder::setValidityPeriod, //
+                        Builder::setAirspace, //
+                        Builder::setStatus);
+                return builder//
+                        .setAirmetPhenomenon(value.getAirmetPhenomenon())//
+                        .setCloudLevels(AirmetCloudLevelsImpl.immutableCopyOf(value.getCloudLevels()))//
+                        .setWind(AirmetWindImpl.immutableCopyOf(value.getWind()))//
+                        .setObscuration(value.getObscuration()//
+                                .map(BuilderHelper::toImmutableList))//
+                        .setVisibility(NumericMeasureImpl.immutableCopyOf(value.getVisibility()))//
+                        .setCancelledReference(AirmetReferenceImpl.immutableCopyOf(value.getCancelledReference()))//
+                        .setAnalysisType(value.getAnalysisType())//
+                        .setAnalysisGeometries(value.getAnalysisGeometries()//
+                                .map(analysisGeometries -> BuilderHelper.toImmutableList(analysisGeometries,
+                                        PhenomenonGeometryWithHeightImpl::immutableCopyOf)))//
+                        .setMovingSpeed(NumericMeasureImpl.immutableCopyOf(value.getMovingSpeed()))//
+                        .setMovingDirection(NumericMeasureImpl.immutableCopyOf(value.getMovingDirection()))//
+                        .setIntensityChange(value.getIntensityChange());
             }
         }
 
@@ -161,28 +159,38 @@ public abstract class AIRMETImpl implements AIRMET, Serializable {
 
         @Override
         @JsonDeserialize(as = AirmetCloudLevelsImpl.class)
-        public Builder setCloudLevels(AirmetCloudLevels cloudLevels) {
+        public Builder setCloudLevels(final AirmetCloudLevels cloudLevels) {
             return super.setCloudLevels(cloudLevels);
         }
 
         @Override
         @JsonDeserialize(as = AirspaceImpl.class)
-        public Builder setAirspace(Airspace airspace) { return super.setAirspace(airspace);}
+        public Builder setAirspace(final Airspace airspace) {
+            return super.setAirspace(airspace);
+        }
 
         @Override
         @JsonDeserialize(as = NumericMeasureImpl.class)
-        public Builder setMovingSpeed(NumericMeasure speed) { return super.setMovingSpeed(speed);}
+        public Builder setMovingSpeed(final NumericMeasure speed) {
+            return super.setMovingSpeed(speed);
+        }
 
         @Override
         @JsonDeserialize(as = NumericMeasureImpl.class)
-        public Builder setMovingDirection(NumericMeasure direction) { return super.setMovingDirection(direction);}
+        public Builder setMovingDirection(final NumericMeasure direction) {
+            return super.setMovingDirection(direction);
+        }
 
         @Override
         @JsonDeserialize(as = NumericMeasureImpl.class)
-        public Builder setVisibility(NumericMeasure visibility) { return super.setVisibility(visibility);}
+        public Builder setVisibility(final NumericMeasure visibility) {
+            return super.setVisibility(visibility);
+        }
 
         @Override
         @JsonDeserialize(as = AirmetWindImpl.class)
-        public Builder setWind(AirmetWind windInfo) { return super.setWind(AirmetWindImpl.immutableCopyOf(windInfo));}
+        public Builder setWind(final AirmetWind windInfo) {
+            return super.setWind(AirmetWindImpl.immutableCopyOf(windInfo));
+        }
     }
 }

--- a/src/main/java/fi/fmi/avi/model/sigmet/immutable/AIRMETImpl.java
+++ b/src/main/java/fi/fmi/avi/model/sigmet/immutable/AIRMETImpl.java
@@ -99,7 +99,9 @@ public abstract class AIRMETImpl implements AIRMET, Serializable {
                 return ((AIRMETImpl) value).toBuilder();
             } else {
                 final Builder builder = builder();
-                AviationWeatherMessageBuilderHelper.copyFrom(builder, value,  //
+                AviationWeatherMessageBuilderHelper.copyFrom(builder, value, //
+                        Builder::setReportStatus, //
+                        Builder::setIssueTime, //
                         Builder::setRemarks, //
                         Builder::setPermissibleUsage, //
                         Builder::setPermissibleUsageReason, //
@@ -110,9 +112,7 @@ public abstract class AIRMETImpl implements AIRMET, Serializable {
                         Builder::setTranslationCentreDesignator, //
                         Builder::setTranslationCentreName, //
                         Builder::setTranslationTime, //
-                        Builder::setTranslatedTAC, //
-                        Builder::setIssueTime, //
-                        Builder::setReportStatus);
+                        Builder::setTranslatedTAC);
                 AirTrafficServicesUnitWeatherMessageBuilderHelper.copyFrom(builder, value, //
                         Builder::setIssuingAirTrafficServicesUnit, //
                         Builder::setMeteorologicalWatchOffice);

--- a/src/main/java/fi/fmi/avi/model/sigmet/immutable/SIGMETBulletinImpl.java
+++ b/src/main/java/fi/fmi/avi/model/sigmet/immutable/SIGMETBulletinImpl.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import fi.fmi.avi.model.bulletin.BulletinHeading;
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinBuilderHelper;
 import fi.fmi.avi.model.bulletin.immutable.BulletinHeadingImpl;
 import fi.fmi.avi.model.sigmet.SIGMET;
 import fi.fmi.avi.model.sigmet.SIGMETBulletin;
@@ -42,7 +43,6 @@ public abstract class SIGMETBulletinImpl implements SIGMETBulletin, Serializable
         return bulletin.map(SIGMETBulletinImpl::immutableCopyOf);
     }
 
-
     public abstract Builder toBuilder();
 
     public static class Builder extends SIGMETBulletinImpl_Builder {
@@ -55,11 +55,14 @@ public abstract class SIGMETBulletinImpl implements SIGMETBulletin, Serializable
             if (value instanceof SIGMETBulletinImpl) {
                 return ((SIGMETBulletinImpl) value).toBuilder();
             } else {
-                return SIGMETBulletinImpl.builder()//
-                        .setHeading(BulletinHeadingImpl.immutableCopyOf(value.getHeading()))//
-                        .setTimeStamp(value.getTimeStamp())//
-                        .addAllMessages(value.getMessages())//
-                        .addAllTimeStampFields(value.getTimeStampFields());
+                final Builder builder = builder();
+                MeteorologicalBulletinBuilderHelper.copyFrom(builder, value, //
+                        Builder::setHeading, //
+                        Builder::addAllMessages, //
+                        SIGMETImpl::immutableCopyOf, //
+                        Builder::setTimeStamp, //
+                        Builder::addAllTimeStampFields);
+                return builder;
             }
         }
 

--- a/src/main/java/fi/fmi/avi/model/sigmet/immutable/SIGMETImpl.java
+++ b/src/main/java/fi/fmi/avi/model/sigmet/immutable/SIGMETImpl.java
@@ -108,7 +108,9 @@ public abstract class SIGMETImpl implements SIGMET, Serializable {
                 return ((SIGMETImpl) value).toBuilder();
             } else {
                 final Builder builder = builder();
-                AviationWeatherMessageBuilderHelper.copyFrom(builder, value,  //
+                AviationWeatherMessageBuilderHelper.copyFrom(builder, value, //
+                        Builder::setReportStatus, //
+                        Builder::setIssueTime, //
                         Builder::setRemarks, //
                         Builder::setPermissibleUsage, //
                         Builder::setPermissibleUsageReason, //
@@ -119,9 +121,7 @@ public abstract class SIGMETImpl implements SIGMET, Serializable {
                         Builder::setTranslationCentreDesignator, //
                         Builder::setTranslationCentreName, //
                         Builder::setTranslationTime, //
-                        Builder::setTranslatedTAC, //
-                        Builder::setIssueTime, //
-                        Builder::setReportStatus);
+                        Builder::setTranslatedTAC);
                 AirTrafficServicesUnitWeatherMessageBuilderHelper.copyFrom(builder, value, //
                         Builder::setIssuingAirTrafficServicesUnit, //
                         Builder::setMeteorologicalWatchOffice);

--- a/src/main/java/fi/fmi/avi/model/sigmet/immutable/SIGMETImpl.java
+++ b/src/main/java/fi/fmi/avi/model/sigmet/immutable/SIGMETImpl.java
@@ -1,9 +1,12 @@
 package fi.fmi.avi.model.sigmet.immutable;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 import org.inferred.freebuilder.FreeBuilder;
 
@@ -35,10 +38,10 @@ import fi.fmi.avi.model.sigmet.VAInfo;
 @FreeBuilder
 @JsonDeserialize(builder = SIGMETImpl.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({ "status", "issuingAirTrafficServicesUnit", "meteorologicalWatchOffice", "sequenceNumber", "issueTime", "validityPeriod", "airspace",
-        "analysisGeometries", "forecastGeometries", "movingSpeed", "movingDirection", "volcano", "noVolcanicAshExpected", "volcanicAshMovedToFIR",
-        "cancelledReport", "remarks", "permissibleUsage", "permissibleUsageReason", "permissibleUsageSupplementary", "translated", "translatedBulletinID",
-        "translatedBulletinReceptionTime", "translationCentreDesignator", "translationCentreName", "translationTime", "translatedTAC" })
+@JsonPropertyOrder({ "reportStatus", "cancelMessage", "issuingAirTrafficServicesUnit", "meteorologicalWatchOffice", "sequenceNumber", "issueTime",
+        "validityPeriod", "airspace", "analysisGeometries", "forecastGeometries", "movingSpeed", "movingDirection", "volcano", "noVolcanicAshExpected",
+        "volcanicAshMovedToFIR", "cancelledReport", "remarks", "permissibleUsage", "permissibleUsageReason", "permissibleUsageSupplementary", "translated",
+        "translatedBulletinID", "translatedBulletinReceptionTime", "translationCentreDesignator", "translationCentreName", "translationTime", "translatedTAC" })
 public abstract class SIGMETImpl implements SIGMET, Serializable {
 
     public static Builder builder() {
@@ -57,6 +60,13 @@ public abstract class SIGMETImpl implements SIGMET, Serializable {
     public static Optional<SIGMETImpl> immutableCopyOf(final Optional<SIGMET> sigmet) {
         Objects.requireNonNull(sigmet);
         return sigmet.map(SIGMETImpl::immutableCopyOf);
+    }
+
+    @Override
+    @JsonIgnore
+    @Deprecated
+    public SigmetAirmetReportStatus getStatus() {
+        return SIGMET.super.getStatus();
     }
 
     public abstract Builder toBuilder();
@@ -89,6 +99,8 @@ public abstract class SIGMETImpl implements SIGMET, Serializable {
         @Deprecated
         public Builder() {
             this.setTranslated(false);
+            this.setReportStatus(ReportStatus.NORMAL);
+            this.setCancelMessage(false);
         }
 
         public static Builder from(final SIGMET value) {
@@ -117,7 +129,7 @@ public abstract class SIGMETImpl implements SIGMET, Serializable {
                         Builder::setSequenceNumber, //
                         Builder::setValidityPeriod, //
                         Builder::setAirspace, //
-                        Builder::setStatus);
+                        Builder::setCancelMessage);
                 return builder//
                         .setSigmetPhenomenon(value.getSigmetPhenomenon())//
                         .setCancelledReference(SigmetReferenceImpl.immutableCopyOf(value.getCancelledReference()))//
@@ -219,6 +231,61 @@ public abstract class SIGMETImpl implements SIGMET, Serializable {
         @JsonDeserialize(as = AirspaceImpl.class)
         public Builder setAirspace(final Airspace airspace) {
             return super.setAirspace(airspace);
+        }
+
+        @Deprecated
+        public Builder mapStatus(final UnaryOperator<SigmetAirmetReportStatus> mapper) {
+            requireNonNull(mapper, "mapper");
+            return setStatus(mapper.apply(getStatus()));
+        }
+
+        /**
+         * Provides the current builder value of the status property.
+         *
+         * Note, this method is provided for backward compatibility with previous versions of the API. The <code>status</code> is no longer
+         * explicitly stored. This implementation uses {@link SigmetAirmetReportStatus#fromReportStatus(ReportStatus, boolean)} instead to determine the
+         * returned value on-the-fly.
+         *
+         * @return the message status
+         *
+         * @deprecated migrate to using a combination of {@link #getReportStatus()} and {@link #isCancelMessage()} instead
+         */
+        @Deprecated
+        public SigmetAirmetReportStatus getStatus() {
+            return SigmetAirmetReportStatus.fromReportStatus(getReportStatus().orElse(ReportStatus.NORMAL), isCancelMessage());
+        }
+
+        /**
+         * Sets the SIGMET-specific message status.
+         *
+         * Note, this method is provided for backward compatibility with previous versions of the API. The <code>status</code> is no longer
+         * explicitly stored. Instead, this method sets other property values with the following logic:
+         * <dl>
+         *     <dt>{@link fi.fmi.avi.model.AviationCodeListUser.SigmetAirmetReportStatus#CANCELLATION CANCELLATION}</dt>
+         *     <dd>
+         *         <code>reportStatus = {@link fi.fmi.avi.model.AviationWeatherMessage.ReportStatus#NORMAL NORMAL}</code><br>
+         *         <code>cancelMessage = true</code><br>
+         *     </dd>
+         *
+         *     <dt>{@link fi.fmi.avi.model.AviationCodeListUser.SigmetAirmetReportStatus#NORMAL NORMAL}</dt>
+         *     <dd>
+         *         <code>reportStatus = {@link fi.fmi.avi.model.AviationWeatherMessage.ReportStatus#NORMAL NORMAL}</code><br>
+         *         <code>cancelMessage = false</code><br>
+         *     </dd>
+         * </dl>
+         *
+         * @param status
+         *         the status to set
+         *
+         * @return builder
+         *
+         * @deprecated migrate to using a combination of {@link #setReportStatus(ReportStatus)} and {@link #setCancelMessage(boolean)} instead
+         */
+        @Deprecated
+        public Builder setStatus(final SigmetAirmetReportStatus status) {
+            requireNonNull(status);
+            return setReportStatus(status.getReportStatus())//
+                    .setCancelMessage(status.isCancelMessage());
         }
     }
 }

--- a/src/main/java/fi/fmi/avi/model/sigmet/immutable/SIGMETImpl.java
+++ b/src/main/java/fi/fmi/avi/model/sigmet/immutable/SIGMETImpl.java
@@ -252,7 +252,7 @@ public abstract class SIGMETImpl implements SIGMET, Serializable {
          */
         @Deprecated
         public SigmetAirmetReportStatus getStatus() {
-            return SigmetAirmetReportStatus.fromReportStatus(getReportStatus().orElse(ReportStatus.NORMAL), isCancelMessage());
+            return SigmetAirmetReportStatus.fromReportStatus(getReportStatus(), isCancelMessage());
         }
 
         /**

--- a/src/main/java/fi/fmi/avi/model/swx/SpaceWeatherAdvisoryAnalysis.java
+++ b/src/main/java/fi/fmi/avi/model/swx/SpaceWeatherAdvisoryAnalysis.java
@@ -3,10 +3,9 @@ package fi.fmi.avi.model.swx;
 import java.util.List;
 import java.util.Optional;
 
-import fi.fmi.avi.model.AviationWeatherMessageOrCollection;
 import fi.fmi.avi.model.PartialOrCompleteTimeInstant;
 
-public interface SpaceWeatherAdvisoryAnalysis extends AviationWeatherMessageOrCollection {
+public interface SpaceWeatherAdvisoryAnalysis {
     PartialOrCompleteTimeInstant getTime();
 
     Type getAnalysisType();

--- a/src/main/java/fi/fmi/avi/model/swx/SpaceWeatherRegion.java
+++ b/src/main/java/fi/fmi/avi/model/swx/SpaceWeatherRegion.java
@@ -4,9 +4,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import fi.fmi.avi.model.AviationWeatherMessageOrCollection;
-
-public interface SpaceWeatherRegion extends AviationWeatherMessageOrCollection {
+public interface SpaceWeatherRegion {
 
     Optional<AirspaceVolume> getAirSpaceVolume();
 

--- a/src/main/java/fi/fmi/avi/model/swx/immutable/SpaceWeatherAdvisoryImpl.java
+++ b/src/main/java/fi/fmi/avi/model/swx/immutable/SpaceWeatherAdvisoryImpl.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import fi.fmi.avi.model.AviationWeatherMessageBuilderHelper;
 import fi.fmi.avi.model.PartialDateTime;
 import fi.fmi.avi.model.PartialOrCompleteTime;
 import fi.fmi.avi.model.PartialOrCompleteTimeInstant;
@@ -83,32 +84,29 @@ public abstract class SpaceWeatherAdvisoryImpl implements SpaceWeatherAdvisory, 
             if (value instanceof SpaceWeatherAdvisoryImpl) {
                 return ((SpaceWeatherAdvisoryImpl) value).toBuilder();
             } else {
-                final Builder retval = builder();
-
-                //From AviationWeatherMessage:
-                retval.setPermissibleUsage(value.getPermissibleUsage());
-                retval.setPermissibleUsageReason(value.getPermissibleUsageReason());
-                retval.setPermissibleUsageSupplementary(value.getPermissibleUsageSupplementary());
-                retval.setTranslated(value.isTranslated());
-                retval.setTranslatedBulletinID(value.getTranslatedBulletinID());
-                retval.setTranslatedBulletinReceptionTime(value.getTranslatedBulletinReceptionTime());
-                retval.setTranslationCentreDesignator(value.getTranslationCentreDesignator());
-                retval.setTranslationCentreName(value.getTranslationCentreName());
-                retval.setTranslationTime(value.getTranslationTime());
-                retval.setTranslatedTAC(value.getTranslatedTAC());
-                retval.setRemarks(value.getRemarks());
-                retval.setIssueTime(value.getIssueTime());
-
-                //From SpaceWeatherAdvisory:
-                retval.setIssuingCenter(IssuingCenterImpl.immutableCopyOf(value.getIssuingCenter()))
+                final Builder builder = builder();
+                AviationWeatherMessageBuilderHelper.copyFrom(builder, value,  //
+                        Builder::setRemarks, //
+                        Builder::setPermissibleUsage, //
+                        Builder::setPermissibleUsageReason, //
+                        Builder::setPermissibleUsageSupplementary, //
+                        Builder::setTranslated, //
+                        Builder::setTranslatedBulletinID, //
+                        Builder::setTranslatedBulletinReceptionTime, //
+                        Builder::setTranslationCentreDesignator, //
+                        Builder::setTranslationCentreName, //
+                        Builder::setTranslationTime, //
+                        Builder::setTranslatedTAC, //
+                        Builder::setIssueTime, //
+                        Builder::setReportStatus);
+                return builder//
+                        .setIssuingCenter(IssuingCenterImpl.immutableCopyOf(value.getIssuingCenter()))
                         .setAdvisoryNumber(AdvisoryNumberImpl.immutableCopyOf(value.getAdvisoryNumber()))
                         .setReplaceAdvisoryNumber(AdvisoryNumberImpl.immutableCopyOf(value.getReplaceAdvisoryNumber()))
+                        .addAllPhenomena(value.getPhenomena().stream()//
+                                .map(p -> SpaceWeatherPhenomenon.from(p.getType(), p.getSeverity())))//
+                        .addAllAnalyses(value.getAnalyses().stream().map(SpaceWeatherAdvisoryAnalysisImpl::immutableCopyOf))//
                         .setNextAdvisory(NextAdvisoryImpl.immutableCopyOf(value.getNextAdvisory()));
-
-                retval.addAllPhenomena(value.getPhenomena().stream()//
-                        .map(p -> SpaceWeatherPhenomenon.from(p.getType(), p.getSeverity())));
-                retval.addAllAnalyses(value.getAnalyses().stream().map(SpaceWeatherAdvisoryAnalysisImpl::immutableCopyOf));
-                return retval;
             }
         }
 

--- a/src/main/java/fi/fmi/avi/model/swx/immutable/SpaceWeatherAdvisoryImpl.java
+++ b/src/main/java/fi/fmi/avi/model/swx/immutable/SpaceWeatherAdvisoryImpl.java
@@ -86,7 +86,9 @@ public abstract class SpaceWeatherAdvisoryImpl implements SpaceWeatherAdvisory, 
                 return ((SpaceWeatherAdvisoryImpl) value).toBuilder();
             } else {
                 final Builder builder = builder();
-                AviationWeatherMessageBuilderHelper.copyFrom(builder, value,  //
+                AviationWeatherMessageBuilderHelper.copyFrom(builder, value, //
+                        Builder::setReportStatus, //
+                        Builder::setIssueTime, //
                         Builder::setRemarks, //
                         Builder::setPermissibleUsage, //
                         Builder::setPermissibleUsageReason, //
@@ -97,9 +99,7 @@ public abstract class SpaceWeatherAdvisoryImpl implements SpaceWeatherAdvisory, 
                         Builder::setTranslationCentreDesignator, //
                         Builder::setTranslationCentreName, //
                         Builder::setTranslationTime, //
-                        Builder::setTranslatedTAC, //
-                        Builder::setIssueTime, //
-                        Builder::setReportStatus);
+                        Builder::setTranslatedTAC);
                 return builder//
                         .setIssuingCenter(IssuingCenterImpl.immutableCopyOf(value.getIssuingCenter()))
                         .setAdvisoryNumber(AdvisoryNumberImpl.immutableCopyOf(value.getAdvisoryNumber()))

--- a/src/main/java/fi/fmi/avi/model/swx/immutable/SpaceWeatherAdvisoryImpl.java
+++ b/src/main/java/fi/fmi/avi/model/swx/immutable/SpaceWeatherAdvisoryImpl.java
@@ -78,6 +78,7 @@ public abstract class SpaceWeatherAdvisoryImpl implements SpaceWeatherAdvisory, 
         @Deprecated
         Builder() {
             this.setTranslated(false);
+            this.setReportStatus(ReportStatus.NORMAL);
         }
 
         public static Builder from(final SpaceWeatherAdvisory value) {

--- a/src/main/java/fi/fmi/avi/model/swx/immutable/SpaceWeatherBulletinImpl.java
+++ b/src/main/java/fi/fmi/avi/model/swx/immutable/SpaceWeatherBulletinImpl.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import fi.fmi.avi.model.bulletin.BulletinHeading;
 import fi.fmi.avi.model.bulletin.DataTypeDesignatorT1;
 import fi.fmi.avi.model.bulletin.DataTypeDesignatorT2;
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinBuilderHelper;
 import fi.fmi.avi.model.bulletin.immutable.BulletinHeadingImpl;
 import fi.fmi.avi.model.swx.SpaceWeatherAdvisory;
 import fi.fmi.avi.model.swx.SpaceWeatherBulletin;
@@ -55,11 +56,14 @@ public abstract class SpaceWeatherBulletinImpl implements SpaceWeatherBulletin, 
             if (value instanceof SpaceWeatherBulletinImpl) {
                 return ((SpaceWeatherBulletinImpl) value).toBuilder();
             } else {
-                return builder()//
-                        .setHeading(BulletinHeadingImpl.immutableCopyOf(value.getHeading()))//
-                        .setTimeStamp(value.getTimeStamp())//
-                        .addAllTimeStampFields(value.getTimeStampFields())//
-                        .addAllMessages(value.getMessages());
+                final Builder builder = builder();
+                MeteorologicalBulletinBuilderHelper.copyFrom(builder, value, //
+                        Builder::setHeading, //
+                        Builder::addAllMessages, //
+                        SpaceWeatherAdvisoryImpl::immutableCopyOf, //
+                        Builder::setTimeStamp, //
+                        Builder::addAllTimeStampFields);
+                return builder;
             }
         }
 

--- a/src/main/java/fi/fmi/avi/model/taf/TAF.java
+++ b/src/main/java/fi/fmi/avi/model/taf/TAF.java
@@ -7,6 +7,8 @@ import fi.fmi.avi.model.AerodromeWeatherMessage;
 import fi.fmi.avi.model.AviationCodeListUser;
 import fi.fmi.avi.model.AviationWeatherMessage;
 import fi.fmi.avi.model.PartialOrCompleteTimePeriod;
+import fi.fmi.avi.model.immutable.AerodromeImpl;
+import fi.fmi.avi.model.taf.immutable.TAFReferenceImpl;
 
 /**
  * Created by rinne on 30/01/15.
@@ -18,11 +20,14 @@ public interface TAF extends AerodromeWeatherMessage, AviationCodeListUser {
      * Returns the TAF message status.
      *
      * @return the status of the TAF message
+     *
      * @deprecated migrate to using a combination of {@link AviationWeatherMessage#getReportStatus()}, {@link #isCancelMessage()} and
      * {@link #isMissingMessage()} instead
      */
     @Deprecated
-    TAFStatus getStatus();
+    default TAFStatus getStatus() {
+        return TAFStatus.fromReportStatus(getReportStatus().orElse(ReportStatus.NORMAL), isCancelMessage(), isMissingMessage());
+    }
 
     Optional<PartialOrCompleteTimePeriod> getValidityTime();
 
@@ -37,7 +42,12 @@ public interface TAF extends AerodromeWeatherMessage, AviationCodeListUser {
      * @return the reference to the previously issued, amended message
      */
     @Deprecated
-    Optional<TAFReference> getReferredReport();
+    default Optional<TAFReference> getReferredReport() {
+        return getReferredReportValidPeriod().map(referredReportValidPeriod -> TAFReferenceImpl.builder()
+                .setAerodrome(AerodromeImpl.immutableCopyOf(this.getAerodrome()))
+                .setValidityTime(referredReportValidPeriod)
+                .build());
+    }
 
     boolean isCancelMessage();
 

--- a/src/main/java/fi/fmi/avi/model/taf/TAF.java
+++ b/src/main/java/fi/fmi/avi/model/taf/TAF.java
@@ -26,7 +26,7 @@ public interface TAF extends AerodromeWeatherMessage, AviationCodeListUser {
      */
     @Deprecated
     default TAFStatus getStatus() {
-        return TAFStatus.fromReportStatus(getReportStatus().orElse(ReportStatus.NORMAL), isCancelMessage(), isMissingMessage());
+        return TAFStatus.fromReportStatus(getReportStatus(), isCancelMessage(), isMissingMessage());
     }
 
     Optional<PartialOrCompleteTimePeriod> getValidityTime();

--- a/src/main/java/fi/fmi/avi/model/taf/TAFForecastBuilderHelper.java
+++ b/src/main/java/fi/fmi/avi/model/taf/TAFForecastBuilderHelper.java
@@ -1,12 +1,9 @@
 package fi.fmi.avi.model.taf;
 
+import static fi.fmi.avi.model.BuilderHelper.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import fi.fmi.avi.model.AviationCodeListUser;
 import fi.fmi.avi.model.immutable.CloudForecastImpl;
@@ -121,27 +118,5 @@ public final class TAFForecastBuilderHelper {
                     .map(CloudForecastImpl::immutableCopyOf)//
                     .ifPresent(builder::setCloud);
         }
-    }
-
-    /**
-     * Return an immutable copy of provided list converting each element to immutable.
-     *
-     * @param list
-     *         source list
-     * @param toImmutable
-     *         function converting element to immutable
-     * @param <T>
-     *         base type of elements
-     * @param <I>
-     *         immutable type of elements
-     *
-     * @return immutable copy
-     */
-    public static <T, I extends T> List<T> toImmutableList(final List<T> list, final Function<T, I> toImmutable) {
-        requireNonNull(list, "list");
-        requireNonNull(toImmutable, "toImmutable");
-        return list.isEmpty() ? Collections.emptyList() : Collections.unmodifiableList(list.stream()//
-                .map(toImmutable)//
-                .collect(Collectors.toList()));
     }
 }

--- a/src/main/java/fi/fmi/avi/model/taf/immutable/TAFBaseForecastImpl.java
+++ b/src/main/java/fi/fmi/avi/model/taf/immutable/TAFBaseForecastImpl.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
+import fi.fmi.avi.model.BuilderHelper;
 import fi.fmi.avi.model.CloudForecast;
 import fi.fmi.avi.model.NumericMeasure;
 import fi.fmi.avi.model.SurfaceWind;
@@ -95,7 +96,7 @@ public abstract class TAFBaseForecastImpl implements TAFBaseForecast, Serializab
             if (value instanceof TAFBaseForecast) {
                 final TAFBaseForecast fromBaseForecast = (TAFBaseForecast) value;
                 setTemperatures(fromBaseForecast.getTemperatures()//
-                        .map(list -> TAFForecastBuilderHelper.toImmutableList(list, TAFAirTemperatureForecastImpl::immutableCopyOf)));
+                        .map(list -> BuilderHelper.toImmutableList(list, TAFAirTemperatureForecastImpl::immutableCopyOf)));
             }
             return this;
         }
@@ -106,7 +107,7 @@ public abstract class TAFBaseForecastImpl implements TAFBaseForecast, Serializab
             if (value instanceof TAFBaseForecast) {
                 final TAFBaseForecast fromBaseForecast = (TAFBaseForecast) value;
                 fromBaseForecast.getTemperatures()//
-                        .map(list -> TAFForecastBuilderHelper.toImmutableList(list, TAFAirTemperatureForecastImpl::immutableCopyOf))//
+                        .map(list -> BuilderHelper.toImmutableList(list, TAFAirTemperatureForecastImpl::immutableCopyOf))//
                         .ifPresent(this::setTemperatures);
             }
             return this;

--- a/src/main/java/fi/fmi/avi/model/taf/immutable/TAFBulletinImpl.java
+++ b/src/main/java/fi/fmi/avi/model/taf/immutable/TAFBulletinImpl.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import fi.fmi.avi.model.bulletin.BulletinHeading;
 import fi.fmi.avi.model.bulletin.DataTypeDesignatorT1;
 import fi.fmi.avi.model.bulletin.DataTypeDesignatorT2;
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinBuilderHelper;
 import fi.fmi.avi.model.bulletin.immutable.BulletinHeadingImpl;
 import fi.fmi.avi.model.taf.TAF;
 import fi.fmi.avi.model.taf.TAFBulletin;
@@ -56,11 +57,14 @@ public abstract class TAFBulletinImpl implements TAFBulletin, Serializable {
             if (value instanceof TAFBulletinImpl) {
                 return ((TAFBulletinImpl) value).toBuilder();
             } else {
-                return TAFBulletinImpl.builder()//
-                        .setHeading(BulletinHeadingImpl.immutableCopyOf(value.getHeading()))//
-                        .setTimeStamp(value.getTimeStamp())//
-                        .addAllTimeStampFields(value.getTimeStampFields())//
-                        .addAllMessages(value.getMessages());
+                final Builder builder = TAFBulletinImpl.builder();
+                MeteorologicalBulletinBuilderHelper.copyFrom(builder, value, //
+                        Builder::setHeading, //
+                        Builder::addAllMessages, //
+                        TAFImpl::immutableCopyOf, //
+                        Builder::setTimeStamp, //
+                        Builder::addAllTimeStampFields);
+                return builder;
             }
         }
 
@@ -89,7 +93,6 @@ public abstract class TAFBulletinImpl implements TAFBulletin, Serializable {
             return super.build();
         }
         */
-
 
         @Override
         @JsonDeserialize(as = BulletinHeadingImpl.class)

--- a/src/main/java/fi/fmi/avi/model/taf/immutable/TAFImpl.java
+++ b/src/main/java/fi/fmi/avi/model/taf/immutable/TAFImpl.java
@@ -283,7 +283,7 @@ public abstract class TAFImpl implements TAF, Serializable {
          */
         @Deprecated
         public TAFStatus getStatus() {
-            return TAFStatus.fromReportStatus(getReportStatus().orElse(ReportStatus.NORMAL), isCancelMessage(), isMissingMessage());
+            return TAFStatus.fromReportStatus(getReportStatus(), isCancelMessage(), isMissingMessage());
         }
 
         /**

--- a/src/main/java/fi/fmi/avi/model/taf/immutable/TAFImpl.java
+++ b/src/main/java/fi/fmi/avi/model/taf/immutable/TAFImpl.java
@@ -47,8 +47,8 @@ import fi.fmi.avi.model.taf.TAFReference;
 @FreeBuilder
 @JsonDeserialize(builder = TAFImpl.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
-@JsonPropertyOrder({ "aerodrome", "issueTime", "validityTime", "baseForecast", "changeForecasts", "isCancelledMessage", "isMissingMessage",
-        "referredReportValidPeriod", "reportStatus", "remarks", "permissibleUsage", "permissibleUsageReason", "permissibleUsageSupplementary", "translated",
+@JsonPropertyOrder({ "reportStatus", "cancelMessage", "missingMessage", "aerodrome", "issueTime", "validityTime", "baseForecast", "changeForecasts",
+        "referredReportValidPeriod", "remarks", "permissibleUsage", "permissibleUsageReason", "permissibleUsageSupplementary", "translated",
         "translatedBulletinID", "translatedBulletinReceptionTime", "translationCentreDesignator", "translationCentreName", "translationTime", "translatedTAC" })
 public abstract class TAFImpl implements TAF, Serializable {
 
@@ -87,7 +87,7 @@ public abstract class TAFImpl implements TAF, Serializable {
     @JsonIgnore
     @Deprecated
     public TAFStatus getStatus() {
-        return TAFStatus.fromReportStatus(getReportStatus().orElse(ReportStatus.NORMAL), isCancelMessage(), isMissingMessage());
+        return TAF.super.getStatus();
     }
 
     /**
@@ -108,10 +108,7 @@ public abstract class TAFImpl implements TAF, Serializable {
     @JsonIgnore
     @Deprecated
     public Optional<TAFReference> getReferredReport() {
-        return getReferredReportValidPeriod().map(referredReportValidPeriod -> TAFReferenceImpl.builder()
-                .setAerodrome(AerodromeImpl.immutableCopyOf(this.getAerodrome()))
-                .setValidityTime(referredReportValidPeriod)
-                .build());
+        return TAF.super.getReferredReport();
     }
 
     public abstract Builder toBuilder();

--- a/src/main/java/fi/fmi/avi/model/taf/immutable/TAFImpl.java
+++ b/src/main/java/fi/fmi/avi/model/taf/immutable/TAFImpl.java
@@ -160,7 +160,9 @@ public abstract class TAFImpl implements TAF, Serializable {
                 return ((TAFImpl) value).toBuilder();
             } else {
                 final Builder builder = builder();
-                AviationWeatherMessageBuilderHelper.copyFrom(builder, value,  //
+                AviationWeatherMessageBuilderHelper.copyFrom(builder, value, //
+                        Builder::setReportStatus, //
+                        Builder::setIssueTime, //
                         Builder::setRemarks, //
                         Builder::setPermissibleUsage, //
                         Builder::setPermissibleUsageReason, //
@@ -171,9 +173,7 @@ public abstract class TAFImpl implements TAF, Serializable {
                         Builder::setTranslationCentreDesignator, //
                         Builder::setTranslationCentreName, //
                         Builder::setTranslationTime, //
-                        Builder::setTranslatedTAC, //
-                        Builder::setIssueTime, //
-                        Builder::setReportStatus);
+                        Builder::setTranslatedTAC);
                 AerodromeWeatherMessageBuilderHelper.copyFrom(builder, value,  //
                         Builder::setAerodrome);
                 return builder//

--- a/src/test/java/fi/fmi/avi/converter/json/JSONConverterTest.java
+++ b/src/test/java/fi/fmi/avi/converter/json/JSONConverterTest.java
@@ -1,12 +1,13 @@
 package fi.fmi.avi.converter.json;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Objects;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,6 +27,7 @@ import fi.fmi.avi.converter.ConversionHints;
 import fi.fmi.avi.converter.ConversionResult;
 import fi.fmi.avi.converter.json.conf.JSONConverter;
 import fi.fmi.avi.model.AviationCodeListUser;
+import fi.fmi.avi.model.AviationWeatherMessage;
 import fi.fmi.avi.model.PartialDateTime;
 import fi.fmi.avi.model.PartialOrCompleteTimeInstant;
 import fi.fmi.avi.model.PartialOrCompleteTimePeriod;
@@ -58,89 +60,84 @@ public class JSONConverterTest {
     @Autowired
     private AviMessageConverter converter;
 
+    private static void assertSuccess(final ConversionResult<?> result) {
+        assertEquals("Expected SUCCESS, but had issues: " + result.getConversionIssues(), //
+                ConversionResult.Status.SUCCESS, result.getStatus());
+    }
+
+    private static String readResource(final String resourceName) throws IOException {
+        try (InputStream inputStream = JSONConverterTest.class.getResourceAsStream(resourceName)) {
+            requireNonNull(inputStream, "inputStream");
+            return IOUtils.toString(inputStream, "UTF-8");
+        }
+    }
+
     @Test
     public void testTAFParsing() throws Exception {
-        final InputStream is = JSONConverterTest.class.getResourceAsStream("taf1.json");
-        Objects.requireNonNull(is);
-        final String input = IOUtils.toString(is,"UTF-8");
-        is.close();
+        final String input = readResource("taf1.json");
         final ConversionResult<TAF> result = converter.convertMessage(input, JSONConverter.JSON_STRING_TO_TAF_POJO, ConversionHints.EMPTY);
-        assertTrue(ConversionResult.Status.SUCCESS == result.getStatus());
+        assertSuccess(result);
     }
 
     @Test
     public void testMETARParsing() throws Exception {
-        final InputStream is = JSONConverterTest.class.getResourceAsStream("metar1.json");
-        Objects.requireNonNull(is);
-        final String input = IOUtils.toString(is, "UTF-8");
-        is.close();
+        final String input = readResource("metar1.json");
         final ConversionResult<METAR> result = converter.convertMessage(input, JSONConverter.JSON_STRING_TO_METAR_POJO, ConversionHints.EMPTY);
-        assertTrue(ConversionResult.Status.SUCCESS == result.getStatus());
+        assertSuccess(result);
     }
 
     @Test
     public void testSIGMETParsing() throws Exception {
-        final InputStream is = JSONConverterTest.class.getResourceAsStream("sigmet1.json");
-        Objects.requireNonNull(is);
-        final String input = IOUtils.toString(is, "UTF-8");
-        is.close();
+        final String input = readResource("sigmet1.json");
         final ConversionResult<SIGMET> result = converter.convertMessage(input, JSONConverter.JSON_STRING_TO_SIGMET_POJO, ConversionHints.EMPTY);
-        assertTrue(ConversionResult.Status.SUCCESS == result.getStatus());
+        assertSuccess(result);
     }
 
     @Test
     public void testTAFBulletinParsing() throws Exception {
-        final InputStream is = JSONConverterTest.class.getResourceAsStream("tafBulletin1.json");
-        Objects.requireNonNull(is);
-        final String input = IOUtils.toString(is, "UTF-8");
-        is.close();
+        final String input = readResource("tafBulletin1.json");
         final ConversionResult<TAFBulletin> result = converter.convertMessage(input, JSONConverter.JSON_STRING_TO_TAF_BULLETIN_POJO, ConversionHints.EMPTY);
-        assertTrue(ConversionResult.Status.SUCCESS == result.getStatus());
+        assertSuccess(result);
     }
 
     @Test
     public void testSIGMETBulletinParsing() throws Exception {
-        final InputStream is = JSONConverterTest.class.getResourceAsStream("sigmetBulletin1.json");
-        Objects.requireNonNull(is);
-        final String input = IOUtils.toString(is, "UTF-8");
-        is.close();
-        final ConversionResult<SIGMETBulletin> result = converter.convertMessage(input, JSONConverter.JSON_STRING_TO_SIGMET_BULLETIN_POJO, ConversionHints.EMPTY);
-        assertTrue(ConversionResult.Status.SUCCESS == result.getStatus());
+        final String input = readResource("sigmetBulletin1.json");
+        final ConversionResult<SIGMETBulletin> result = converter.convertMessage(input, JSONConverter.JSON_STRING_TO_SIGMET_BULLETIN_POJO,
+                ConversionHints.EMPTY);
+        assertSuccess(result);
     }
 
     @Test
     public void testGenericBulletinParsing() throws Exception {
-        final InputStream is = JSONConverterTest.class.getResourceAsStream("generic-bulletin1.json");
-        Objects.requireNonNull(is);
-        final String input = IOUtils.toString(is, "UTF-8");
-        is.close();
-        final ConversionResult<GenericMeteorologicalBulletin> result = converter.convertMessage(input, JSONConverter.JSON_STRING_TO_GENERIC_BULLETIN_POJO, ConversionHints.EMPTY);
-        assertTrue(ConversionResult.Status.SUCCESS == result.getStatus());
+        final String input = readResource("generic-bulletin1.json");
+        final ConversionResult<GenericMeteorologicalBulletin> result = converter.convertMessage(input, JSONConverter.JSON_STRING_TO_GENERIC_BULLETIN_POJO,
+                ConversionHints.EMPTY);
+        assertSuccess(result);
     }
 
     @Test
     public void testGenericCustomBulletinParsing() throws Exception {
-        final InputStream is = JSONConverterTest.class.getResourceAsStream("custom-bulletin1.json");
-        Objects.requireNonNull(is);
-        final String input = IOUtils.toString(is, "UTF-8");
-        is.close();
-        final ConversionResult<GenericMeteorologicalBulletin> result = converter.convertMessage(input, JSONConverter.JSON_STRING_TO_GENERIC_BULLETIN_POJO, ConversionHints.EMPTY);
-        assertTrue(ConversionResult.Status.SUCCESS == result.getStatus());
+        final String input = readResource("custom-bulletin1.json");
+        final ConversionResult<GenericMeteorologicalBulletin> result = converter.convertMessage(input, JSONConverter.JSON_STRING_TO_GENERIC_BULLETIN_POJO,
+                ConversionHints.EMPTY);
+        assertSuccess(result);
     }
-
 
     @Test
     public void testTAFSerialization() throws Exception {
-        final InputStream is = JSONConverterTest.class.getResourceAsStream("taf1.json");
-        Objects.requireNonNull(is);
-        final ObjectMapper om = new ObjectMapper();
-        om.registerModule(new Jdk8Module());
-        om.registerModule(new JavaTimeModule());
-        final JsonNode reference = om.readerFor(TAFImpl.class).readTree(is);
-        is.close();
+        final ObjectMapper om;
+        final JsonNode reference;
+        try (InputStream is = JSONConverterTest.class.getResourceAsStream("taf1.json")) {
+            requireNonNull(is);
+            om = new ObjectMapper();
+            om.registerModule(new Jdk8Module());
+            om.registerModule(new JavaTimeModule());
+            reference = om.readerFor(TAFImpl.class).readTree(is);
+        }
 
         final TAFImpl.Builder builder = TAFImpl.builder();
-        builder.setStatus(AviationCodeListUser.TAFStatus.NORMAL)
+        builder.setReportStatus(AviationWeatherMessage.ReportStatus.NORMAL)
                 .setIssueTime(PartialOrCompleteTimeInstant.createIssueTime("271137Z"))
                 .setAerodrome(AerodromeImpl.builder().setDesignator("EFVA").build())
                 .setValidityTime(PartialOrCompleteTimePeriod.createValidityTime("2712/2812"))
@@ -148,7 +145,7 @@ public class JSONConverterTest {
                         .setForecastWeather(WeatherImpl.fromCodes("-RA"))
                         .setPrevailingVisibility(NumericMeasureImpl.of(8000.0, "m"))//
                         .setSurfaceWind(SurfaceWindImpl.builder()
-                                .setMeanWindDirection(NumericMeasureImpl.of(140,"deg"))
+                                .setMeanWindDirection(NumericMeasureImpl.of(140, "deg"))
                                 .setMeanWindSpeed(NumericMeasureImpl.of(15.0, "[kn_i]"))
                                 .setWindGust(NumericMeasureImpl.of(25.0, "[kn_i]"))
                                 .build())
@@ -156,42 +153,34 @@ public class JSONConverterTest {
                                 .setLayers(Arrays.asList(CloudLayerImpl.builder()
                                         .setBase(NumericMeasureImpl.of(2000, "[ft_i]"))
                                         .setAmount(AviationCodeListUser.CloudAmount.SCT)
-                                        .build(),
-                                        CloudLayerImpl.builder()
-                                                .setBase(NumericMeasureImpl.of(5000, "[ft_i]"))
-                                                .setAmount(AviationCodeListUser.CloudAmount.OVC)
-                                                .build()))
-                                .build()
-                                )
+                                        .build(), CloudLayerImpl.builder()
+                                        .setBase(NumericMeasureImpl.of(5000, "[ft_i]"))
+                                        .setAmount(AviationCodeListUser.CloudAmount.OVC)
+                                        .build()))
+                                .build())
                         .build());
-        builder.setChangeForecasts(Arrays.asList(
-                TAFChangeForecastImpl.builder()
+        builder.setChangeForecasts(Arrays.asList(TAFChangeForecastImpl.builder()
                         .setForecastWeather(WeatherImpl.fromCodes("-RA"))
                         .setChangeIndicator(AviationCodeListUser.TAFChangeIndicator.BECOMING)
                         .setPeriodOfChange(PartialOrCompleteTimePeriod.createValidityTimeDHDH("2715/2717"))
                         .setPrevailingVisibility(NumericMeasureImpl.of(5000.0, "m"))
                         .setCloud(CloudForecastImpl.builder()
-                                .setLayers(Collections.singletonList(CloudLayerImpl.builder().setBase(NumericMeasureImpl.of(700, "[ft_i]"))
-                                        .setAmount(AviationCodeListUser.CloudAmount.BKN)
-                                        .build()))
-                                .build()
-                        )
-                        .build(),
-                TAFChangeForecastImpl.builder()
+                                .setLayers(Collections.singletonList(
+                                        CloudLayerImpl.builder().setBase(NumericMeasureImpl.of(700, "[ft_i]")).setAmount(AviationCodeListUser.CloudAmount.BKN).build()))
+                                .build())
+                        .build(), TAFChangeForecastImpl.builder()
                         .setForecastWeather(WeatherImpl.fromCodes("RASN"))
                         .setChangeIndicator(AviationCodeListUser.TAFChangeIndicator.PROBABILITY_40)
                         .setPeriodOfChange(PartialOrCompleteTimePeriod.createValidityTimeDHDH("2715/2720"))
                         .setPrevailingVisibility(NumericMeasureImpl.of(4000.0, "m"))
-                        .build(),
-                TAFChangeForecastImpl.builder()
+                        .build(), TAFChangeForecastImpl.builder()
                         .setChangeIndicator(AviationCodeListUser.TAFChangeIndicator.BECOMING)
                         .setPeriodOfChange(PartialOrCompleteTimePeriod.createValidityTimeDHDH("2720/2722"))//
                         .setSurfaceWind(SurfaceWindImpl.builder()
                                 .setMeanWindDirection(NumericMeasureImpl.of(160, "deg"))
                                 .setMeanWindSpeed(NumericMeasureImpl.of(12.0, "[kn_i]"))
                                 .build())
-                        .build(),
-                TAFChangeForecastImpl.builder()
+                        .build(), TAFChangeForecastImpl.builder()
                         .setChangeIndicator(AviationCodeListUser.TAFChangeIndicator.TEMPORARY_FLUCTUATIONS)
                         .setPeriodOfChange(PartialOrCompleteTimePeriod.createValidityTimeDHDH("2720/2724"))
                         .setPrevailingVisibility(NumericMeasureImpl.of(8000.0, "m"))
@@ -203,12 +192,15 @@ public class JSONConverterTest {
                         .setPeriodOfChange(PartialOrCompleteTimePeriod.createValidityTimeDHDH("2802/2806"))
                         .setPrevailingVisibility(NumericMeasureImpl.of(3000.0, "m"))
                         .setCloud(CloudForecastImpl.builder()
-                                .setLayers(Collections.singletonList(CloudLayerImpl.builder().setBase(NumericMeasureImpl.of(400, "[ft_i]"))
+                                .setLayers(Collections.singletonList(CloudLayerImpl.builder()
+                                        .setBase(NumericMeasureImpl.of(400, "[ft_i]"))
                                         .setAmount(AviationCodeListUser.CloudAmount.BKN)
-                                        .build())).build()).build()));
+                                        .build()))
+                                .build())
+                        .build()));
 
         final ConversionResult<String> result = converter.convertMessage(builder.build(), JSONConverter.TAF_POJO_TO_JSON_STRING, ConversionHints.EMPTY);
-        assertTrue(ConversionResult.Status.SUCCESS == result.getStatus());
+        assertSuccess(result);
         assertTrue(result.getConvertedMessage().isPresent());
         final JsonNode resultJSON = om.readTree(result.getConvertedMessage().get());
         assertEquals(reference, resultJSON);
@@ -216,13 +208,10 @@ public class JSONConverterTest {
 
     @Test
     public void testSIGMETBulletinSerialization() throws Exception {
-        final InputStream is = JSONConverterTest.class.getResourceAsStream("sigmet1.json");
-        Objects.requireNonNull(is);
-        final String reference = IOUtils.toString(is, "UTF-8");
-        is.close();
+        final String reference = readResource("sigmet1.json");
         final ConversionResult<SIGMET> result = converter.convertMessage(reference, JSONConverter.JSON_STRING_TO_SIGMET_POJO, ConversionHints.EMPTY);
-        System.err.println(result.getStatus()+" "+result.getConversionIssues());
-        System.err.println("sigmet:"+result.getConvertedMessage().get());
+        assertSuccess(result);
+        System.err.println("sigmet:" + result.getConvertedMessage().get());
 
         final SIGMETBulletinImpl.Builder builder = SIGMETBulletinImpl.builder()//
                 .setHeading(BulletinHeadingImpl.builder()//
@@ -234,16 +223,16 @@ public class JSONConverterTest {
                         .setIssueTime(PartialOrCompleteTimeInstant.of(PartialDateTime.ofDayHourMinute(2, 5, 0)))//
                         .build());
 
-        builder.addMessages(SIGMETImpl.Builder.from(result.getConvertedMessage().get())
-                .setTranslatedTAC("EFIN SIGMET 1 VALID 170750/170950 EFKL-\n"//
-                        + "EFIN FINLAND FIR SEV TURB FCST AT 0740Z\n"//
-                        + "S OF LINE N5953 E01931 -\n"//
-                        + "N6001 E02312 - N6008 E02606 - N6008\n"//
-                        + "E02628 FL220-340 MOV N 15KT\n"//
-                        + "WKN=").setTranslated(false).build());
+        builder.addMessages(SIGMETImpl.Builder.from(result.getConvertedMessage().get()).setTranslatedTAC("EFIN SIGMET 1 VALID 170750/170950 EFKL-\n"//
+                + "EFIN FINLAND FIR SEV TURB FCST AT 0740Z\n"//
+                + "S OF LINE N5953 E01931 -\n"//
+                + "N6001 E02312 - N6008 E02606 - N6008\n"//
+                + "E02628 FL220-340 MOV N 15KT\n"//
+                + "WKN=").setTranslated(false).build());
         final SIGMETBulletin msg = builder.build();
 
-        final ConversionResult<String> jsonResult = this.converter.convertMessage(msg, JSONConverter.SIGMET_BULLETIN_POJO_TO_JSON_STRING, ConversionHints.EMPTY);
+        final ConversionResult<String> jsonResult = this.converter.convertMessage(msg, JSONConverter.SIGMET_BULLETIN_POJO_TO_JSON_STRING,
+                ConversionHints.EMPTY);
         assertEquals(ConversionResult.Status.SUCCESS, jsonResult.getStatus());
 
         TestCase.assertTrue(jsonResult.getConvertedMessage().isPresent());

--- a/src/test/java/fi/fmi/avi/model/airmet/immutable/AirmetTest.java
+++ b/src/test/java/fi/fmi/avi/model/airmet/immutable/AirmetTest.java
@@ -1,8 +1,13 @@
 package fi.fmi.avi.model.airmet.immutable;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 
 import org.junit.Test;
@@ -32,77 +37,71 @@ import fi.fmi.avi.model.sigmet.immutable.AirmetCloudLevelsImpl;
 
 public class AirmetTest {
 
-    ObjectMapper om=new ObjectMapper().registerModule(new JavaTimeModule()).registerModule(new Jdk8Module()).enable(SerializationFeature.INDENT_OUTPUT);
-
-    static String testGeoJson1 = "{\"type\":\"Polygon\",\"exteriorRingPositions\":[0,52,0,60,10,60,10,52,0,52]}}";
-
-    static String testGeoJson2 = "{\"type\":\"Polygon\",\"exteriorRingPositions\":[0,52,0,60,5,60,5,52,0,52]}}";
+    private static final String TEST_GEO_JSON_1 = "{\"type\":\"Polygon\",\"exteriorRingPositions\":[0,52,0,60,10,60,10,52,0,52]}}";
+    private static final String TEST_GEO_JSON_2 = "{\"type\":\"Polygon\",\"exteriorRingPositions\":[0,52,0,60,5,60,5,52,0,52]}}";
+    private final ObjectMapper om = new ObjectMapper().registerModule(new JavaTimeModule())
+            .registerModule(new Jdk8Module())
+            .enable(SerializationFeature.INDENT_OUTPUT);
 
     public PhenomenonGeometryWithHeight getAnalysis() {
-        Optional<Geometry> anGeometry=Optional.empty();
+        Optional<Geometry> anGeometry = Optional.empty();
 
         try {
-            anGeometry=Optional.ofNullable(om.readValue(testGeoJson1, Geometry.class));
-        } catch (IOException e) {
+            anGeometry = Optional.ofNullable(om.readValue(TEST_GEO_JSON_1, Geometry.class));
+        } catch (final IOException e) {
             e.printStackTrace();
         }
 
-        PhenomenonGeometryWithHeightImpl.Builder an=new PhenomenonGeometryWithHeightImpl.Builder()
-                .setTime(PartialOrCompleteTimeInstant.of(ZonedDateTime.parse("2018-10-22T13:50:00Z")))
+        final PhenomenonGeometryWithHeightImpl.Builder an = new PhenomenonGeometryWithHeightImpl.Builder().setTime(
+                PartialOrCompleteTimeInstant.of(ZonedDateTime.parse("2018-10-22T13:50:00Z")))
                 .setGeometry(TacOrGeoGeometryImpl.of(anGeometry.get()))
-                .setApproximateLocation(false)
-                ;
+                .setApproximateLocation(false);
         return an.build();
     }
 
-
     public AIRMET buildAirmet() {
-        AviationCodeListUser.AeronauticalAirmetWeatherPhenomenon airmetPhenomenon= AviationCodeListUser.AeronauticalAirmetWeatherPhenomenon.BKN_CLD;
-
-        AirmetCloudLevelsImpl.Builder levels = new AirmetCloudLevelsImpl.Builder()
-                .setCloudBase(NumericMeasureImpl.of(0, "SFC"))
+        final AirmetCloudLevelsImpl.Builder levels = new AirmetCloudLevelsImpl.Builder().setCloudBase(NumericMeasureImpl.of(0, "SFC"))
                 .setCloudTop(NumericMeasureImpl.of(7000, "[ft_i]"));
 
-        Airspace airspace=new AirspaceImpl.Builder().setDesignator("EHAA").setType(Airspace.AirspaceType.FIR).setName("AMSTERDAM").build();
+        final Airspace airspace = new AirspaceImpl.Builder().setDesignator("EHAA").setType(Airspace.AirspaceType.FIR).setName("AMSTERDAM").build();
 
-
-        AIRMETImpl.Builder sm=new AIRMETImpl.Builder()
+        final AIRMETImpl.Builder sm = AIRMETImpl.builder()
                 .setIssueTime(PartialOrCompleteTimeInstant.of(ZonedDateTime.parse("2018-10-22T14:00:00Z")))
                 .setIssuingAirTrafficServicesUnit(new UnitPropertyGroupImpl.Builder().setPropertyGroup("AMSTERDAM", "EHAA", "FIR").build())
                 .setMeteorologicalWatchOffice(new UnitPropertyGroupImpl.Builder().setPropertyGroup("De Bilt", "EHDB", "MWO").build())
                 .setAirspace(airspace)
                 .setSequenceNumber("1")
                 .setStatus(AviationCodeListUser.SigmetAirmetReportStatus.NORMAL)
-                .setValidityPeriod(new PartialOrCompleteTimePeriod.Builder()
+                .setValidityPeriod(PartialOrCompleteTimePeriod.builder()
                         .setStartTime(PartialOrCompleteTimeInstant.of(ZonedDateTime.parse("2018-10-22T14:00:00Z")))
                         .setEndTime(PartialOrCompleteTimeInstant.of(ZonedDateTime.parse("2018-10-22T18:00:00Z")))
                         .build())
-                .setAnalysisGeometries(Arrays.asList(getAnalysis()))
+                .setAnalysisGeometries(Collections.singletonList(getAnalysis()))
                 .setAnalysisType(SigmetAnalysisType.OBSERVATION)
                 .setIntensityChange(SigmetIntensityChange.WEAKENING)
 
-                //                .setAnalysis(Arrays.asList(getAnalysis()))
+                //                .setAnalysis(Collections.singletonList(getAnalysis()))
                 .setAirmetPhenomenon(AviationCodeListUser.AeronauticalAirmetWeatherPhenomenon.BKN_CLD)
                 .setCloudLevels(levels.build())
-                .setTranslated(false)
-        ;
+                .setTranslated(false);
 
         return sm.build();
     }
 
     @Test
     public void testBuild() throws IOException {
-        AIRMET sm=buildAirmet();
-        assert(sm.areAllTimeReferencesComplete());
-        System.err.println("TAC: "+sm.toString());
-        String json=om.writeValueAsString(sm);
-        System.err.println("JSON: "+json);
-        JsonNode smNode=om.readTree(json.getBytes());
-        assert(!smNode.isNull());
-        assert(smNode.has("status"));
-        assert(smNode.get("status").asText().equals("NORMAL"));
+        final AIRMET sm = buildAirmet();
+        assertTrue(sm.areAllTimeReferencesComplete());
+        System.err.println("TAC: " + sm.toString());
+        final String json = om.writeValueAsString(sm);
+        System.err.println("JSON: " + json);
+        final JsonNode smNode = om.readTree(json.getBytes(StandardCharsets.UTF_8));
+        assertFalse(smNode.isNull());
+        assertTrue(smNode.has("reportStatus"));
+        assertEquals("NORMAL", smNode.get("reportStatus").asText());
+        assertTrue(!smNode.has("cancelMessage") || smNode.get("cancelMessage").asBoolean() == false);
 
-        AIRMET readBackAirmet=om.readValue(json, AIRMETImpl.class);
-        System.err.println("bottom: "+readBackAirmet.getCloudLevels().get().getCloudBase().getValue());
+        final AIRMET readBackAirmet = om.readValue(json, AIRMETImpl.class);
+        System.err.println("bottom: " + readBackAirmet.getCloudLevels().get().getCloudBase().getValue());
     }
 }

--- a/src/test/java/fi/fmi/avi/model/sigmet/immutable/SigmetTest.java
+++ b/src/test/java/fi/fmi/avi/model/sigmet/immutable/SigmetTest.java
@@ -1,8 +1,13 @@
 package fi.fmi.avi.model.sigmet.immutable;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Optional;
 
 import org.junit.Test;
@@ -31,83 +36,80 @@ import fi.fmi.avi.model.sigmet.SigmetIntensityChange;
 
 public class SigmetTest {
 
-    ObjectMapper om=new ObjectMapper().registerModule(new JavaTimeModule()).registerModule(new Jdk8Module()).enable(SerializationFeature.INDENT_OUTPUT);
-
-    static String testGeoJson1 = "{\"type\":\"Polygon\",\"exteriorRingPositions\":[0,52,0,60,10,60,10,52,0,52]}}";
-
-    static String testGeoJson2 = "{\"type\":\"Polygon\",\"exteriorRingPositions\":[0,52,0,60,5,60,5,52,0,52]}}";
+    private static final String TEST_GEO_JSON_1 = "{\"type\":\"Polygon\",\"exteriorRingPositions\":[0,52,0,60,10,60,10,52,0,52]}}";
+    private static final String TEST_GEO_JSON_2 = "{\"type\":\"Polygon\",\"exteriorRingPositions\":[0,52,0,60,5,60,5,52,0,52]}}";
+    private final ObjectMapper om = new ObjectMapper().registerModule(new JavaTimeModule())
+            .registerModule(new Jdk8Module())
+            .enable(SerializationFeature.INDENT_OUTPUT);
 
     public PhenomenonGeometryWithHeight getAnalysis() {
-        Optional<Geometry> anGeometry=Optional.empty();
+        Optional<Geometry> anGeometry = Optional.empty();
 
         try {
-            anGeometry=Optional.ofNullable(om.readValue(testGeoJson1, Geometry.class));
-        } catch (IOException e) {
+            anGeometry = Optional.ofNullable(om.readValue(TEST_GEO_JSON_1, Geometry.class));
+        } catch (final IOException e) {
             e.printStackTrace();
         }
 
-        PhenomenonGeometryWithHeightImpl.Builder an=new PhenomenonGeometryWithHeightImpl.Builder()
-                .setTime(PartialOrCompleteTimeInstant.of(ZonedDateTime.parse("2018-10-22T13:50:00Z")))
+        final PhenomenonGeometryWithHeightImpl.Builder an = new PhenomenonGeometryWithHeightImpl.Builder().setTime(
+                PartialOrCompleteTimeInstant.of(ZonedDateTime.parse("2018-10-22T13:50:00Z")))
                 .setGeometry(TacOrGeoGeometryImpl.of(anGeometry.get()))
-                .setApproximateLocation(false)
-                ;
+                .setApproximateLocation(false);
         return an.build();
     }
 
     public PhenomenonGeometry getForecast() {
-        Optional<Geometry> fcGeometry=Optional.empty();
+        Optional<Geometry> fcGeometry = Optional.empty();
 
         try {
-            fcGeometry=Optional.ofNullable(om.readValue(testGeoJson2, Geometry.class));
-        } catch (IOException e) {
+            fcGeometry = Optional.ofNullable(om.readValue(TEST_GEO_JSON_2, Geometry.class));
+        } catch (final IOException e) {
             e.printStackTrace();
         }
 
-        PhenomenonGeometryImpl.Builder an=new PhenomenonGeometryImpl.Builder()
-                .setTime(PartialOrCompleteTimeInstant.of(ZonedDateTime.parse("2018-10-22T18:00:00Z")))
+        final PhenomenonGeometryImpl.Builder an = new PhenomenonGeometryImpl.Builder().setTime(
+                PartialOrCompleteTimeInstant.of(ZonedDateTime.parse("2018-10-22T18:00:00Z")))
                 .setGeometry(TacOrGeoGeometryImpl.of(fcGeometry.get()))
-                .setApproximateLocation(false)
-                ;
+                .setApproximateLocation(false);
         return an.build();
     }
 
     public SIGMET buildSigmet() {
-        Airspace airspace=new AirspaceImpl.Builder().setDesignator("EHAA").setType(Airspace.AirspaceType.FIR).setName("AMSTERDAM").build();
+        final Airspace airspace = new AirspaceImpl.Builder().setDesignator("EHAA").setType(Airspace.AirspaceType.FIR).setName("AMSTERDAM").build();
 
-
-        SIGMETImpl.Builder sm=new SIGMETImpl.Builder()
+        final SIGMETImpl.Builder sm = SIGMETImpl.builder()
                 .setIssueTime(PartialOrCompleteTimeInstant.of(ZonedDateTime.parse("2018-10-22T14:00:00Z")))
                 .setIssuingAirTrafficServicesUnit(new UnitPropertyGroupImpl.Builder().setPropertyGroup("AMSTERDAM FIR", "EHAM", "FIR").build())
                 .setMeteorologicalWatchOffice(new UnitPropertyGroupImpl.Builder().setPropertyGroup("De Bilt", "EHDB", "MWO").build())
                 .setAirspace(airspace)
                 .setSequenceNumber("1")
                 .setStatus(AviationCodeListUser.SigmetAirmetReportStatus.NORMAL)
-                .setValidityPeriod(new PartialOrCompleteTimePeriod.Builder()
+                .setValidityPeriod(PartialOrCompleteTimePeriod.builder()
                         .setStartTime(PartialOrCompleteTimeInstant.of(ZonedDateTime.parse("2018-10-22T14:00:00Z")))
                         .setEndTime(PartialOrCompleteTimeInstant.of(ZonedDateTime.parse("2018-10-22T18:00:00Z")))
                         .build())
-                .setAnalysisGeometries(Arrays.asList(getAnalysis()))
-                .setForecastGeometries(Arrays.asList(getForecast()))
+                .setAnalysisGeometries(Collections.singletonList(getAnalysis()))
+                .setForecastGeometries(Collections.singletonList(getForecast()))
                 .setAnalysisType(SigmetAnalysisType.OBSERVATION)
                 .setIntensityChange(SigmetIntensityChange.WEAKENING)
 
-                //                .setAnalysis(Arrays.asList(getAnalysis()))
+                //                .setAnalysis(Collections.singletonList(getAnalysis()))
                 .setSigmetPhenomenon(AviationCodeListUser.AeronauticalSignificantWeatherPhenomenon.EMBD_TS)
-                .setTranslated(false)
-        ;
+                .setTranslated(false);
         return sm.build();
     }
 
     @Test
     public void testBuild() throws IOException {
-        SIGMET sm=buildSigmet();
-        assert(sm.areAllTimeReferencesComplete());
-        System.err.println("TAC: "+sm.toString());
-        String json=om.writeValueAsString(sm);
-        System.err.println("JSON: "+json);
-        JsonNode smNode=om.readTree(json.getBytes());
-        assert(!smNode.isNull());
-        assert(smNode.has("status"));
-        assert(smNode.get("status").asText().equals("NORMAL"));
+        final SIGMET sm = buildSigmet();
+        assertTrue(sm.areAllTimeReferencesComplete());
+        System.err.println("TAC: " + sm.toString());
+        final String json = om.writeValueAsString(sm);
+        System.err.println("JSON: " + json);
+        final JsonNode smNode = om.readTree(json.getBytes(StandardCharsets.UTF_8));
+        assertFalse(smNode.isNull());
+        assertTrue(smNode.has("reportStatus"));
+        assertEquals("NORMAL", smNode.get("reportStatus").asText());
+        assertTrue(!smNode.has("cancelMessage") || smNode.get("cancelMessage").asBoolean() == false);
     }
 }

--- a/src/test/java/fi/fmi/avi/model/taf/immutable/TAFIWXXM21_30_ResilienceTest.java
+++ b/src/test/java/fi/fmi/avi/model/taf/immutable/TAFIWXXM21_30_ResilienceTest.java
@@ -36,6 +36,7 @@ import fi.fmi.avi.model.taf.TAFReference;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 
+@SuppressWarnings("deprecation")
 @RunWith(JUnitParamsRunner.class)
 public class TAFIWXXM21_30_ResilienceTest {
     private static final AerodromeImpl AERODROME = AerodromeImpl.builder()//
@@ -68,8 +69,7 @@ public class TAFIWXXM21_30_ResilienceTest {
                 .setBaseForecast(TAFBaseForecastImpl.builder().buildPartial())//
                 .buildPartial();
         assertEquals(TAFStatus.NORMAL, t.getStatus());
-        assertTrue(t.getReportStatus().isPresent());
-        assertEquals(AviationWeatherMessage.ReportStatus.NORMAL, t.getReportStatus().get());
+        assertEquals(AviationWeatherMessage.ReportStatus.NORMAL, t.getReportStatus());
         assertFalse(t.isCancelMessage());
         assertFalse(t.isMissingMessage());
         assertFalse(t.getReferredReportValidPeriod().isPresent());
@@ -80,8 +80,7 @@ public class TAFIWXXM21_30_ResilienceTest {
                 .setBaseForecast(TAFBaseForecastImpl.builder().buildPartial())//
                 .buildPartial();
         assertEquals(TAFStatus.CANCELLATION, t.getStatus());
-        assertTrue(t.getReportStatus().isPresent());
-        assertEquals(AviationWeatherMessage.ReportStatus.AMENDMENT, t.getReportStatus().get());
+        assertEquals(AviationWeatherMessage.ReportStatus.AMENDMENT, t.getReportStatus());
         assertTrue(t.isCancelMessage());
         assertFalse(t.isMissingMessage());
         assertFalse(t.getReferredReportValidPeriod().isPresent());
@@ -92,8 +91,7 @@ public class TAFIWXXM21_30_ResilienceTest {
                 .setBaseForecast(TAFBaseForecastImpl.builder().buildPartial())//
                 .buildPartial();
         assertEquals(TAFStatus.AMENDMENT, t.getStatus());
-        assertTrue(t.getReportStatus().isPresent());
-        assertEquals(AviationWeatherMessage.ReportStatus.AMENDMENT, t.getReportStatus().get());
+        assertEquals(AviationWeatherMessage.ReportStatus.AMENDMENT, t.getReportStatus());
         assertFalse(t.isCancelMessage());
         assertFalse(t.isMissingMessage());
         assertFalse(t.getReferredReportValidPeriod().isPresent());
@@ -102,8 +100,7 @@ public class TAFIWXXM21_30_ResilienceTest {
         t = TAFImpl.builder().setStatus(TAFStatus.CORRECTION).setBaseForecast(TAFBaseForecastImpl.builder().buildPartial())//
                 .buildPartial();
         assertEquals(TAFStatus.CORRECTION, t.getStatus());
-        assertTrue(t.getReportStatus().isPresent());
-        assertEquals(AviationWeatherMessage.ReportStatus.CORRECTION, t.getReportStatus().get());
+        assertEquals(AviationWeatherMessage.ReportStatus.CORRECTION, t.getReportStatus());
         assertFalse(t.isCancelMessage());
         assertFalse(t.isMissingMessage());
         assertFalse(t.getReferredReportValidPeriod().isPresent());
@@ -139,8 +136,7 @@ public class TAFIWXXM21_30_ResilienceTest {
                 .setReportStatus(AviationWeatherMessage.ReportStatus.NORMAL)//
                 .buildPartial();
         assertEquals(TAFStatus.NORMAL, t.getStatus());
-        assertTrue(t.getReportStatus().isPresent());
-        assertEquals(AviationWeatherMessage.ReportStatus.NORMAL, t.getReportStatus().get());
+        assertEquals(AviationWeatherMessage.ReportStatus.NORMAL, t.getReportStatus());
         assertFalse(t.isCancelMessage());
         assertFalse(t.isMissingMessage());
         assertFalse(t.getReferredReportValidPeriod().isPresent());
@@ -151,8 +147,7 @@ public class TAFIWXXM21_30_ResilienceTest {
                 .setReportStatus(AviationWeatherMessage.ReportStatus.AMENDMENT)//
                 .buildPartial();
         assertEquals(TAFStatus.AMENDMENT, t.getStatus());
-        assertTrue(t.getReportStatus().isPresent());
-        assertEquals(AviationWeatherMessage.ReportStatus.AMENDMENT, t.getReportStatus().get());
+        assertEquals(AviationWeatherMessage.ReportStatus.AMENDMENT, t.getReportStatus());
         assertFalse(t.isCancelMessage());
         assertFalse(t.isMissingMessage());
         assertFalse(t.getReferredReportValidPeriod().isPresent());
@@ -163,8 +158,7 @@ public class TAFIWXXM21_30_ResilienceTest {
                 .setReportStatus(AviationWeatherMessage.ReportStatus.CORRECTION)//
                 .buildPartial();
         assertEquals(TAFStatus.CORRECTION, t.getStatus());
-        assertTrue(t.getReportStatus().isPresent());
-        assertEquals(AviationWeatherMessage.ReportStatus.CORRECTION, t.getReportStatus().get());
+        assertEquals(AviationWeatherMessage.ReportStatus.CORRECTION, t.getReportStatus());
         assertFalse(t.isCancelMessage());
         assertFalse(t.isMissingMessage());
         assertFalse(t.getReferredReportValidPeriod().isPresent());
@@ -177,38 +171,32 @@ public class TAFIWXXM21_30_ResilienceTest {
         TAFImpl.Builder t = TAFImpl.builder().setCancelMessage(true).setReportStatus(AviationWeatherMessage.ReportStatus.AMENDMENT);
         assertEquals(TAFStatus.CANCELLATION, t.getStatus());
         assertTrue(t.isCancelMessage());
-        assertTrue(t.getReportStatus().isPresent());
-        assertEquals(AviationWeatherMessage.ReportStatus.AMENDMENT, t.getReportStatus().get());
+        assertEquals(AviationWeatherMessage.ReportStatus.AMENDMENT, t.getReportStatus());
 
         t = TAFImpl.builder().setReportStatus(AviationWeatherMessage.ReportStatus.AMENDMENT).setCancelMessage(true);
         assertEquals(TAFStatus.CANCELLATION, t.getStatus());
         assertTrue(t.isCancelMessage());
-        assertTrue(t.getReportStatus().isPresent());
-        assertEquals(AviationWeatherMessage.ReportStatus.AMENDMENT, t.getReportStatus().get());
+        assertEquals(AviationWeatherMessage.ReportStatus.AMENDMENT, t.getReportStatus());
 
         t = TAFImpl.builder().setReportStatus(AviationWeatherMessage.ReportStatus.NORMAL).setCancelMessage(true);
         assertEquals(TAFStatus.CANCELLATION, t.getStatus());
         assertTrue(t.isCancelMessage());
-        assertTrue(t.getReportStatus().isPresent());
-        assertEquals(AviationWeatherMessage.ReportStatus.NORMAL, t.getReportStatus().get());
+        assertEquals(AviationWeatherMessage.ReportStatus.NORMAL, t.getReportStatus());
 
         t = TAFImpl.builder().setCancelMessage(true).setReportStatus(AviationWeatherMessage.ReportStatus.NORMAL);
         assertEquals(TAFStatus.CANCELLATION, t.getStatus());
         assertTrue(t.isCancelMessage());
-        assertTrue(t.getReportStatus().isPresent());
-        assertEquals(AviationWeatherMessage.ReportStatus.NORMAL, t.getReportStatus().get());
+        assertEquals(AviationWeatherMessage.ReportStatus.NORMAL, t.getReportStatus());
 
         t = TAFImpl.builder().setReportStatus(AviationWeatherMessage.ReportStatus.CORRECTION).setCancelMessage(true);
         assertEquals(TAFStatus.CANCELLATION, t.getStatus());
         assertTrue(t.isCancelMessage());
-        assertTrue(t.getReportStatus().isPresent());
-        assertEquals(AviationWeatherMessage.ReportStatus.CORRECTION, t.getReportStatus().get());
+        assertEquals(AviationWeatherMessage.ReportStatus.CORRECTION, t.getReportStatus());
 
         t = TAFImpl.builder().setCancelMessage(true).setReportStatus(AviationWeatherMessage.ReportStatus.CORRECTION);
         assertEquals(TAFStatus.CANCELLATION, t.getStatus());
         assertTrue(t.isCancelMessage());
-        assertTrue(t.getReportStatus().isPresent());
-        assertEquals(AviationWeatherMessage.ReportStatus.CORRECTION, t.getReportStatus().get());
+        assertEquals(AviationWeatherMessage.ReportStatus.CORRECTION, t.getReportStatus());
     }
 
     /*
@@ -302,19 +290,23 @@ public class TAFIWXXM21_30_ResilienceTest {
         t = TAFImpl.builder().setReferredReport(TAFReferenceImpl.builder().setAerodrome(ad).setValidityTime(tp1).build()).buildPartial();
         assertTrue(t.getReferredReportValidPeriod().isPresent());
 
-        t = TAFImpl.builder().setReferredReport(TAFReferenceImpl.builder().setAerodrome(ad).setValidityTime(tp1).build()).setStatus(TAFStatus.CANCELLATION)
+        t = TAFImpl.builder()//
+                .setReferredReport(TAFReferenceImpl.builder().setAerodrome(ad).setValidityTime(tp1).build())//
+                .setStatus(TAFStatus.CANCELLATION)//
                 .buildPartial();
         assertTrue(t.getReferredReportValidPeriod().isPresent());
         assertEquals(tp1, t.getReferredReportValidPeriod().get());
 
-        t = TAFImpl.builder().setReferredReport(TAFReferenceImpl.builder().setAerodrome(ad).setValidityTime(tp1).build()).setStatus(TAFStatus.AMENDMENT)
+        t = TAFImpl.builder()//
+                .setReferredReport(TAFReferenceImpl.builder().setAerodrome(ad).setValidityTime(tp1).build())//
+                .setStatus(TAFStatus.AMENDMENT)//
                 .buildPartial();
         assertTrue(t.getReferredReportValidPeriod().isPresent());
         assertEquals(tp1, t.getReferredReportValidPeriod().get());
 
-        t = TAFImpl.builder()
-                .setReferredReport(TAFReferenceImpl.builder().setAerodrome(ad).setValidityTime(tp1).build())
-                .setStatus(TAFStatus.CORRECTION)
+        t = TAFImpl.builder()//
+                .setReferredReport(TAFReferenceImpl.builder().setAerodrome(ad).setValidityTime(tp1).build())//
+                .setStatus(TAFStatus.CORRECTION)//
                 .buildPartial();
         assertTrue(t.getReferredReportValidPeriod().isPresent());
         assertEquals(tp1, t.getReferredReportValidPeriod().get());
@@ -349,8 +341,7 @@ public class TAFIWXXM21_30_ResilienceTest {
     @Parameters(source = TAFIWXXM21_30_ResilienceTest.StatusesProvider.class)
     @Test
     public void testSetStatusMultipleInvocations(final List<TAFStatus> statusesFirst, final List<TAFStatus> statusesLast) {
-        final TAFIWXXM21_30_ResilienceTest.StatusAssertion assertion = TAFIWXXM21_30_ResilienceTest.StatusAssertion.of(
-                last(statusesFirst, statusesLast).orElse(TAFStatus.NORMAL));
+        final TAFIWXXM21_30_ResilienceTest.StatusAssertion assertion = TAFIWXXM21_30_ResilienceTest.StatusAssertion.of(last(statusesFirst, statusesLast).orElse(TAFStatus.NORMAL));
         final TAFImpl.Builder builder = TAFImpl.builder();
         statusesFirst.forEach(builder::setStatus);
         builder//
@@ -365,8 +356,7 @@ public class TAFIWXXM21_30_ResilienceTest {
     @Parameters(source = TAFIWXXM21_30_ResilienceTest.StatusesProvider.class)
     @Test
     public void testSetStatusMultipleInvocationsWithoutReferredReport(final List<TAFStatus> statusesFirst, final List<TAFStatus> statusesLast) {
-        final TAFIWXXM21_30_ResilienceTest.StatusAssertion assertion = TAFIWXXM21_30_ResilienceTest.StatusAssertion.of(
-                last(statusesFirst, statusesLast).orElse(TAFStatus.NORMAL));
+        final TAFIWXXM21_30_ResilienceTest.StatusAssertion assertion = TAFIWXXM21_30_ResilienceTest.StatusAssertion.of(last(statusesFirst, statusesLast).orElse(TAFStatus.NORMAL));
         final TAFImpl.Builder builder = TAFImpl.builder();
         statusesFirst.forEach(builder::setStatus);
         builder.setBaseForecast(BASE_FORECAST);
@@ -379,12 +369,11 @@ public class TAFIWXXM21_30_ResilienceTest {
     private enum StatusAssertion {
         NORMAL(TAFStatus.NORMAL) {
             @Override
-            public void assertStatus(final String message, final TAF taf, final TAFReferenceImpl expectedReferredReport,
-                    final TAFBaseForecastImpl baseForecast) {
+            public void assertStatus(final String message, final TAF taf, final TAFReferenceImpl expectedReferredReport, final TAFBaseForecastImpl baseForecast) {
                 assertEquals("status: " + message, TAFStatus.NORMAL, taf.getStatus());
                 assertEquals("referredReport: " + message, expectedReferredReport, taf.getReferredReport().orElse(null));
 
-                assertEquals("reportStatus: " + message, AviationWeatherMessage.ReportStatus.NORMAL, taf.getReportStatus().orElse(null));
+                assertEquals("reportStatus: " + message, AviationWeatherMessage.ReportStatus.NORMAL, taf.getReportStatus());
                 assertFalse("cancelMessage: " + message, taf.isCancelMessage());
                 final PartialOrCompleteTimePeriod expectedReferredReportValidPeriod = Optional.ofNullable(expectedReferredReport)
                         .flatMap(TAFReference::getValidityTime)
@@ -395,12 +384,11 @@ public class TAFIWXXM21_30_ResilienceTest {
         },//
         AMENDMENT(TAFStatus.AMENDMENT) {
             @Override
-            public void assertStatus(final String message, final TAF taf, final TAFReferenceImpl expectedReferredReport,
-                    final TAFBaseForecastImpl baseForecast) {
+            public void assertStatus(final String message, final TAF taf, final TAFReferenceImpl expectedReferredReport, final TAFBaseForecastImpl baseForecast) {
                 assertEquals("status: " + message, TAFStatus.AMENDMENT, taf.getStatus());
                 assertEquals("referredReport: " + message, expectedReferredReport, taf.getReferredReport().orElse(null));
 
-                assertEquals("reportStatus: " + message, AviationWeatherMessage.ReportStatus.AMENDMENT, taf.getReportStatus().orElse(null));
+                assertEquals("reportStatus: " + message, AviationWeatherMessage.ReportStatus.AMENDMENT, taf.getReportStatus());
                 assertFalse("cancelMessage: " + message, taf.isCancelMessage());
                 final PartialOrCompleteTimePeriod expectedReferredReportValidPeriod = Optional.ofNullable(expectedReferredReport)
                         .flatMap(TAFReference::getValidityTime)
@@ -411,12 +399,11 @@ public class TAFIWXXM21_30_ResilienceTest {
         },//
         CANCELLATION(TAFStatus.CANCELLATION) {
             @Override
-            public void assertStatus(final String message, final TAF taf, final TAFReferenceImpl expectedReferredReport,
-                    final TAFBaseForecastImpl baseForecast) {
+            public void assertStatus(final String message, final TAF taf, final TAFReferenceImpl expectedReferredReport, final TAFBaseForecastImpl baseForecast) {
                 assertEquals("status: " + message, TAFStatus.CANCELLATION, taf.getStatus());
                 assertEquals("referredReport: " + message, expectedReferredReport, taf.getReferredReport().orElse(null));
 
-                assertEquals("reportStatus: " + message, AviationWeatherMessage.ReportStatus.AMENDMENT, taf.getReportStatus().orElse(null));
+                assertEquals("reportStatus: " + message, AviationWeatherMessage.ReportStatus.AMENDMENT, taf.getReportStatus());
                 assertTrue("cancelMessage: " + message, taf.isCancelMessage());
                 final PartialOrCompleteTimePeriod expectedReferredReportValidPeriod = Optional.ofNullable(expectedReferredReport)
                         .flatMap(TAFReference::getValidityTime)
@@ -427,12 +414,11 @@ public class TAFIWXXM21_30_ResilienceTest {
         },//
         CORRECTION(TAFStatus.CORRECTION) {
             @Override
-            public void assertStatus(final String message, final TAF taf, final TAFReferenceImpl expectedReferredReport,
-                    final TAFBaseForecastImpl baseForecast) {
+            public void assertStatus(final String message, final TAF taf, final TAFReferenceImpl expectedReferredReport, final TAFBaseForecastImpl baseForecast) {
                 assertEquals("status: " + message, TAFStatus.CORRECTION, taf.getStatus());
                 assertEquals("referredReport: " + message, expectedReferredReport, taf.getReferredReport().orElse(null));
 
-                assertEquals("reportStatus: " + message, AviationWeatherMessage.ReportStatus.CORRECTION, taf.getReportStatus().orElse(null));
+                assertEquals("reportStatus: " + message, AviationWeatherMessage.ReportStatus.CORRECTION, taf.getReportStatus());
                 assertFalse("cancelMessage: " + message, taf.isCancelMessage());
                 final PartialOrCompleteTimePeriod expectedReferredReportValidPeriod = Optional.ofNullable(expectedReferredReport)
                         .flatMap(TAFReference::getValidityTime)
@@ -443,12 +429,11 @@ public class TAFIWXXM21_30_ResilienceTest {
         },//
         MISSING(TAFStatus.MISSING) {
             @Override
-            public void assertStatus(final String message, final TAF taf, final TAFReferenceImpl expectedReferredReport,
-                    final TAFBaseForecastImpl baseForecast) {
+            public void assertStatus(final String message, final TAF taf, final TAFReferenceImpl expectedReferredReport, final TAFBaseForecastImpl baseForecast) {
                 assertEquals("status: " + message, TAFStatus.MISSING, taf.getStatus());
                 assertEquals("referredReport: " + message, expectedReferredReport, taf.getReferredReport().orElse(null));
 
-                assertEquals("reportStatus: " + message, AviationWeatherMessage.ReportStatus.NORMAL, taf.getReportStatus().orElse(null));
+                assertEquals("reportStatus: " + message, AviationWeatherMessage.ReportStatus.NORMAL, taf.getReportStatus());
                 assertFalse("cancelMessage: " + message, taf.isCancelMessage());
                 final PartialOrCompleteTimePeriod expectedReferredReportValidPeriod = Optional.ofNullable(expectedReferredReport)
                         .flatMap(TAFReference::getValidityTime)
@@ -458,11 +443,10 @@ public class TAFIWXXM21_30_ResilienceTest {
             }
         };//
 
-        private static final Map<TAFStatus, TAFIWXXM21_30_ResilienceTest.StatusAssertion> ASSERTIONS_BY_STATUS = Collections.unmodifiableMap(
-                Arrays.stream(TAFIWXXM21_30_ResilienceTest.StatusAssertion.values())//
-                        .collect(Collectors.toMap(TAFIWXXM21_30_ResilienceTest.StatusAssertion::getStatus, Function.identity(), (a, b) -> {
-                            throw new IllegalArgumentException("Duplicate " + a);
-                        }, () -> new EnumMap<>(TAFStatus.class))));
+        private static final Map<TAFStatus, TAFIWXXM21_30_ResilienceTest.StatusAssertion> ASSERTIONS_BY_STATUS = Collections.unmodifiableMap(Arrays.stream(TAFIWXXM21_30_ResilienceTest.StatusAssertion.values())//
+                .collect(Collectors.toMap(TAFIWXXM21_30_ResilienceTest.StatusAssertion::getStatus, Function.identity(), (a, b) -> {
+                    throw new IllegalArgumentException("Duplicate " + a);
+                }, () -> new EnumMap<>(TAFStatus.class))));
 
         private final TAFStatus status;
 

--- a/src/test/resources/fi/fmi/avi/converter/json/airmet2.json
+++ b/src/test/resources/fi/fmi/avi/converter/json/airmet2.json
@@ -1,5 +1,5 @@
 {
-  "status": "NORMAL",
+  "reportStatus": "NORMAL",
   "issuingAirTrafficServicesUnit": {
     "name": "AMSTERDAM",
     "type": "FIR",
@@ -22,14 +22,14 @@
       "completeTime": "2017-08-27T18:00:00Z"
     }
   },
-  "airspace" : {
-    "designator" : "EHAA",
-    "name" : "AMSTERDAM",
-    "type" : "FIR"
+  "airspace": {
+    "designator": "EHAA",
+    "name": "AMSTERDAM",
+    "type": "FIR"
   },
   "airmetPhenomenon": "MOD_ICE",
-  "permissibleUsage":"NON_OPERATIONAL",
-  "permissibleUsageReason":"EXERCISE",
+  "permissibleUsage": "NON_OPERATIONAL",
+  "permissibleUsageReason": "EXERCISE",
   "analysisType": "OBSERVATION",
   "intensityChange": "NO_CHANGE",
   "analysisGeometries": [

--- a/src/test/resources/fi/fmi/avi/converter/json/airmet_moving.json
+++ b/src/test/resources/fi/fmi/avi/converter/json/airmet_moving.json
@@ -1,5 +1,5 @@
 {
-  "status": "NORMAL",
+  "reportStatus": "NORMAL",
   "issuingAirTrafficServicesUnit": {
     "name": "AMSTERDAM",
     "type": "FIR",
@@ -22,10 +22,10 @@
       "completeTime": "2017-08-27T18:00:00Z"
     }
   },
-  "airspace" : {
-    "designator" : "EHAA",
-    "name" : "AMSTERDAM",
-    "type" : "FIR"
+  "airspace": {
+    "designator": "EHAA",
+    "name": "AMSTERDAM",
+    "type": "FIR"
   },
   "movingDirection": {
     "value": 180.0,
@@ -35,11 +35,10 @@
     "value": 10.0,
     "uom": "[kn_i]"
   },
-  "permissibleUsage":"NON_OPERATIONAL",
-  "permissibleUsageReason":"EXERCISE",
+  "permissibleUsage": "NON_OPERATIONAL",
+  "permissibleUsageReason": "EXERCISE",
   "airmetPhenomenon": "MOD_ICE",
   "analysisType": "OBSERVATION",
-
   "analysisGeometries": [
     {
       "geometry": {
@@ -69,6 +68,7 @@
         "value": 35.0,
         "uom": "FL"
       }
-    } ],
+    }
+  ],
   "intensityChange": "NO_CHANGE"
 }

--- a/src/test/resources/fi/fmi/avi/converter/json/airmet_point_moving.json
+++ b/src/test/resources/fi/fmi/avi/converter/json/airmet_point_moving.json
@@ -1,5 +1,5 @@
 {
-  "status": "NORMAL",
+  "reportStatus": "NORMAL",
   "issuingAirTrafficServicesUnit": {
     "name": "AMSTERDAM",
     "type": "FIR",
@@ -22,10 +22,10 @@
       "completeTime": "2017-08-27T18:00:00Z"
     }
   },
-  "airspace" : {
-    "designator" : "EHAA",
-    "name" : "AMSTERDAM",
-    "type" : "FIR"
+  "airspace": {
+    "designator": "EHAA",
+    "name": "AMSTERDAM",
+    "type": "FIR"
   },
   "movingDirection": {
     "value": 180.0,
@@ -35,11 +35,10 @@
     "value": 10.0,
     "uom": "[kn_i]"
   },
-  "permissibleUsage":"NON_OPERATIONAL",
-  "permissibleUsageReason":"EXERCISE",
+  "permissibleUsage": "NON_OPERATIONAL",
+  "permissibleUsageReason": "EXERCISE",
   "airmetPhenomenon": "MOD_ICE",
   "analysisType": "OBSERVATION",
-
   "analysisGeometries": [
     {
       "geometry": {
@@ -63,6 +62,7 @@
         "value": 35.0,
         "uom": "FL"
       }
-    } ],
+    }
+  ],
   "intensityChange": "NO_CHANGE"
 }

--- a/src/test/resources/fi/fmi/avi/converter/json/metar1.json
+++ b/src/test/resources/fi/fmi/avi/converter/json/metar1.json
@@ -1,5 +1,5 @@
 {
-  "status": "NORMAL",
+  "reportStatus": "NORMAL",
   "issueTime": {
     "partialTime": "--01T24:00Z"
   },

--- a/src/test/resources/fi/fmi/avi/converter/json/sigmet1.json
+++ b/src/test/resources/fi/fmi/avi/converter/json/sigmet1.json
@@ -1,5 +1,5 @@
 {
-  "status": "NORMAL",
+  "reportStatus": "NORMAL",
   "issuingAirTrafficServicesUnit": {
     "name": "AMSTERDAM FIR",
     "type": "FIR",
@@ -15,9 +15,9 @@
     "completeTime": "2017-08-27T11:30:00Z"
   },
   "airspace": {
-    "designator":"EHAA",
-    "name":"AMSTERDAM",
-    "type":"FIR"
+    "designator": "EHAA",
+    "name": "AMSTERDAM",
+    "type": "FIR"
   },
   "validityPeriod": {
     "startTime": {
@@ -28,8 +28,8 @@
     }
   },
   "sigmetPhenomenon": "EMBD_TS",
-  "permissibleUsage":"NON_OPERATIONAL",
-  "permissibleUsageReason":"EXERCISE",
+  "permissibleUsage": "NON_OPERATIONAL",
+  "permissibleUsageReason": "EXERCISE",
   "analysisType": "OBSERVATION",
   "intensityChange": "NO_CHANGE",
   "analysisGeometries": [
@@ -63,8 +63,9 @@
       }
     }
   ],
-  "forecastGeometries":[{
-      "time":  {
+  "forecastGeometries": [
+    {
+      "time": {
         "completeTime": "2017-08-27T18:00:00Z"
       },
       "approximateLocation": false,

--- a/src/test/resources/fi/fmi/avi/converter/json/sigmetBulletin1.json
+++ b/src/test/resources/fi/fmi/avi/converter/json/sigmetBulletin1.json
@@ -11,7 +11,7 @@
   },
   "messages": [
     {
-      "status": "NORMAL",
+      "reportStatus": "NORMAL",
       "issuingAirTrafficServicesUnit": {
         "name": "AMSTERDAM FIR",
         "type": "FIR",
@@ -27,9 +27,9 @@
         "completeTime": "2017-08-27T11:30:00Z"
       },
       "airspace": {
-        "designator":"EHAA",
-        "name":"AMSTERDAM",
-        "type":"FIR"
+        "designator": "EHAA",
+        "name": "AMSTERDAM",
+        "type": "FIR"
       },
       "validityPeriod": {
         "startTime": {
@@ -40,8 +40,8 @@
         }
       },
       "sigmetPhenomenon": "EMBD_TS",
-      "permissibleUsage":"NON_OPERATIONAL",
-      "permissibleUsageReason":"EXERCISE",
+      "permissibleUsage": "NON_OPERATIONAL",
+      "permissibleUsageReason": "EXERCISE",
       "analysisType": "OBSERVATION",
       "intensityChange": "NO_CHANGE",
       "analysisGeometries": [
@@ -75,32 +75,33 @@
           }
         }
       ],
-      "forecastGeometries":[{
-        "time":  {
-          "completeTime": "2017-08-27T18:00:00Z"
-        },
-        "approximateLocation": false,
-        "geometry": {
-          "geoGeometry": {
-            "type": "Polygon",
-            "exteriorRingPositions": [
-              5.0,
-              53.0,
-              6.0,
-              54.0,
-              4.0,
-              55.0,
-              5.0,
-              53.0
-            ]
+      "forecastGeometries": [
+        {
+          "time": {
+            "completeTime": "2017-08-27T18:00:00Z"
+          },
+          "approximateLocation": false,
+          "geometry": {
+            "geoGeometry": {
+              "type": "Polygon",
+              "exteriorRingPositions": [
+                5.0,
+                53.0,
+                6.0,
+                54.0,
+                4.0,
+                55.0,
+                5.0,
+                53.0
+              ]
+            }
           }
         }
-      }
       ],
       "translated": true
     },
     {
-      "status": "NORMAL",
+      "reportStatus": "NORMAL",
       "issuingAirTrafficServicesUnit": {
         "name": "AMSTERDAM",
         "type": "FIR",
@@ -129,8 +130,8 @@
         "type": "FIR"
       },
       "sigmetPhenomenon": "EMBD_TS",
-      "permissibleUsage":"NON_OPERATIONAL",
-      "permissibleUsageReason":"EXERCISE",
+      "permissibleUsage": "NON_OPERATIONAL",
+      "permissibleUsageReason": "EXERCISE",
       "analysisType": "OBSERVATION",
       "intensityChange": "NO_CHANGE",
       "analysisGeometries": [
@@ -164,27 +165,28 @@
           }
         }
       ],
-      "forecastGeometries":[{
-        "time":  {
-          "completeTime": "2017-08-27T18:00:00Z"
-        },
-        "approximateLocation": false,
-        "geometry": {
-          "geoGeometry": {
-            "type": "Polygon",
-            "exteriorRingPositions": [
-              5.0,
-              53.0,
-              6.0,
-              54.0,
-              4.0,
-              55.0,
-              5.0,
-              53.0
-            ]
+      "forecastGeometries": [
+        {
+          "time": {
+            "completeTime": "2017-08-27T18:00:00Z"
+          },
+          "approximateLocation": false,
+          "geometry": {
+            "geoGeometry": {
+              "type": "Polygon",
+              "exteriorRingPositions": [
+                5.0,
+                53.0,
+                6.0,
+                54.0,
+                4.0,
+                55.0,
+                5.0,
+                53.0
+              ]
+            }
           }
         }
-      }
       ],
       "VAInfo": {
         "volcano": {

--- a/src/test/resources/fi/fmi/avi/converter/json/sigmet_moving.json
+++ b/src/test/resources/fi/fmi/avi/converter/json/sigmet_moving.json
@@ -1,5 +1,5 @@
 {
-  "status": "NORMAL",
+  "reportStatus": "NORMAL",
   "issuingAirTrafficServicesUnit": {
     "name": "AMSTERDAM FIR",
     "type": "FIR",
@@ -15,9 +15,9 @@
     "completeTime": "2017-08-27T11:30:00Z"
   },
   "airspace": {
-    "designator":"EHAA",
-    "name":"AMSTERDAM",
-    "type":"FIR"
+    "designator": "EHAA",
+    "name": "AMSTERDAM",
+    "type": "FIR"
   },
   "validityPeriod": {
     "startTime": {
@@ -28,8 +28,8 @@
     }
   },
   "sigmetPhenomenon": "EMBD_TS",
-  "permissibleUsage":"NON_OPERATIONAL",
-  "permissibleUsageReason":"EXERCISE",
+  "permissibleUsage": "NON_OPERATIONAL",
+  "permissibleUsageReason": "EXERCISE",
   "analysisType": "OBSERVATION",
   "intensityChange": "NO_CHANGE",
   "analysisGeometries": [

--- a/src/test/resources/fi/fmi/avi/converter/json/swx1.json
+++ b/src/test/resources/fi/fmi/avi/converter/json/swx1.json
@@ -400,5 +400,6 @@
       "completeTime": "2020-02-27T01:00:00Z"
     }
   },
-  "permissibleUsageReason": "TEST"
+  "permissibleUsageReason": "TEST",
+  "reportStatus": "NORMAL"
 }

--- a/src/test/resources/fi/fmi/avi/converter/json/vasigmet1.json
+++ b/src/test/resources/fi/fmi/avi/converter/json/vasigmet1.json
@@ -1,5 +1,5 @@
 {
-  "status": "NORMAL",
+  "reportStatus": "NORMAL",
   "issuingAirTrafficServicesUnit": {
     "name": "AMSTERDAM",
     "type": "FIR",

--- a/src/test/resources/fi/fmi/avi/model/metar/immutable/metar11.json
+++ b/src/test/resources/fi/fmi/avi/model/metar/immutable/metar11.json
@@ -1,146 +1,145 @@
 {
-  "status" : "NORMAL",
-  "issueTime" : {
-    "completeTime" : "2017-07-11T11:11:00Z"
+  "reportStatus": "NORMAL",
+  "issueTime": {
+    "completeTime": "2017-07-11T11:11:00Z"
   },
-  "aerodrome" : {
-    "designator" : "EFHK"
+  "aerodrome": {
+    "designator": "EFHK"
   },
-  "surfaceWind" : {
-    "meanWindDirection" : {
+  "surfaceWind": {
+    "meanWindDirection": {
       "value": 150.0,
-      "uom" : "deg"
+      "uom": "deg"
     },
-    "meanWindSpeed" : {
+    "meanWindSpeed": {
       "value": 8.0,
-      "uom" : "[kn_i]"
+      "uom": "[kn_i]"
     }
   },
-  "visibility" : {
-    "prevailingVisibility" : {
+  "visibility": {
+    "prevailingVisibility": {
       "value": 700.0,
-      "uom" : "m"
+      "uom": "m"
     }
   },
   "runwayVisualRanges": [
     {
-      "runwayDirection" : {
-        "associatedAirportHeliport" : {
-          "designator" : "EFHK"
+      "runwayDirection": {
+        "associatedAirportHeliport": {
+          "designator": "EFHK"
         },
-        "designator" : "04R"
+        "designator": "04R"
       },
-      "pastTendency" : "NO_CHANGE",
-      "meanRVR" : {
+      "pastTendency": "NO_CHANGE",
+      "meanRVR": {
         "value": 1500.0,
-        "uom" : "m"
+        "uom": "m"
       }
     },
     {
-    "runwayDirection" : {
-        "associatedAirportHeliport" : {
-          "designator" : "EFHK"
+      "runwayDirection": {
+        "associatedAirportHeliport": {
+          "designator": "EFHK"
         },
-        "designator" : "15"
+        "designator": "15"
       },
-      "pastTendency" : "UPWARD",
-      "meanRVR" : {
+      "pastTendency": "UPWARD",
+      "meanRVR": {
         "value": 1000.0,
-        "uom" : "m"
+        "uom": "m"
       }
     },
     {
-    "runwayDirection" : {
-        "associatedAirportHeliport" : {
-          "designator" : "EFHK"
+      "runwayDirection": {
+        "associatedAirportHeliport": {
+          "designator": "EFHK"
         },
-        "designator" : "22L"
+        "designator": "22L"
       },
-      "pastTendency" : "NO_CHANGE",
-      "meanRVR" : {
+      "pastTendency": "NO_CHANGE",
+      "meanRVR": {
         "value": 1200.0,
-        "uom" : "m"
+        "uom": "m"
       }
     },
     {
-     "runwayDirection" : {
-        "associatedAirportHeliport" : {
-          "designator" : "EFHK"
+      "runwayDirection": {
+        "associatedAirportHeliport": {
+          "designator": "EFHK"
         },
-        "designator" : "04L"
+        "designator": "04L"
       },
-      "pastTendency" : "UPWARD",
-      "varyingRVRMaximumOperator" : "ABOVE",
-      "varyingRVRMinimum" : {
+      "pastTendency": "UPWARD",
+      "varyingRVRMaximumOperator": "ABOVE",
+      "varyingRVRMinimum": {
         "value": 1000.0,
-        "uom" : "m"
+        "uom": "m"
       },
-      "varyingRVRMaximum" : {
+      "varyingRVRMaximum": {
         "value": 1500.0,
-        "uom" : "m"
+        "uom": "m"
       }
     }
   ],
   "presentWeather": [
     {
-      "code" : "SN",
-      "description" : "Precipitation of snow"
+      "code": "SN",
+      "description": "Precipitation of snow"
     }
   ],
-  "clouds" : {
-    "verticalVisibility" : {
+  "clouds": {
+    "verticalVisibility": {
       "value": 600.0,
-      "uom" : "[ft_i]"
+      "uom": "[ft_i]"
     }
   },
-  "altimeterSettingQNH" : {
+  "altimeterSettingQNH": {
     "value": 1023.0,
-    "uom" : "hPa"
+    "uom": "hPa"
   },
-  "airTemperature" : {
+  "airTemperature": {
     "value": -8.0,
-    "uom" : "degC"
+    "uom": "degC"
   },
-  "dewpointTemperature" : {
+  "dewpointTemperature": {
     "value": -10.0,
-    "uom" : "degC"
+    "uom": "degC"
   },
-  "seaState" : {
-    "seaSurfaceTemperature" : {
+  "seaState": {
+    "seaSurfaceTemperature": {
       "value": -1,
-      "uom" : "degC"
+      "uom": "degC"
     },
-    "seaSurfaceState" : "CALM_RIPPLED"
+    "seaSurfaceState": "CALM_RIPPLED"
   },
   "trends": [
     {
-      "periodOfChange" : {
-        "endTime" : {
-          "partialTime" : "--T15:30"
+      "periodOfChange": {
+        "endTime": {
+          "partialTime": "--T15:30"
         }
       },
-      "changeIndicator" : "TEMPORARY_FLUCTUATIONS",
+      "changeIndicator": "TEMPORARY_FLUCTUATIONS",
       "forecastWeather": [
         {
-          "code" : "+SHRA",
-          "description" : "Heavy showery precipitation of rain"
+          "code": "+SHRA",
+          "description": "Heavy showery precipitation of rain"
         }
       ],
-      "cloud" : {
+      "cloud": {
         "layers": [
           {
-            "amount" : "BKN",
-            "base" : {
+            "amount": "BKN",
+            "base": {
               "value": 1200.0,
-              "uom" : "[ft_i]"
+              "uom": "[ft_i]"
             },
-            "cloudType" : "CB"
+            "cloudType": "CB"
           }
         ]
       }
-
     }
   ],
-  "translatedTAC" : "METAR EFHK 111111Z 15008KT 0700 R04R/1500N R15/1000U R22L/1200N R04L/1000VP1500U SN VV006 M08/M10 Q1023 WM01/S1 TEMPO TL1530 +SHRA BKN012CB=",
+  "translatedTAC": "METAR EFHK 111111Z 15008KT 0700 R04R/1500N R15/1000U R22L/1200N R04L/1000VP1500U SN VV006 M08/M10 Q1023 WM01/S1 TEMPO TL1530 +SHRA BKN012CB=",
   "translated": true
 }


### PR DESCRIPTION
Closes #74.

To ensure a proper value exists for `getReportStatus()` I had to deprecate the `getStatus()` method of various message types and possibly add `isCancelMessage()` or `isMissingMessage()`. A default transition implementation was added for the `getStatus()` method.
