### PR TITLE
Add support for GTS socket protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- ...
+- Add support for GTS socket protocol. [#101]
 
 ### Changed
 
@@ -92,3 +92,5 @@ Previous changelog entries are available on [GitHub releases page](https://githu
 [#92]: https://github.com/fmidev/fmi-avi-messageconverter/pull/92
 
 [#98]: https://github.com/fmidev/fmi-avi-messageconverter/pull/98
+
+[#101]: https://github.com/fmidev/fmi-avi-messageconverter/issues/101

--- a/src/main/java/fi/fmi/avi/util/GTSDataExchangeParseException.java
+++ b/src/main/java/fi/fmi/avi/util/GTSDataExchangeParseException.java
@@ -1,0 +1,38 @@
+package fi.fmi.avi.util;
+
+import java.util.Locale;
+
+public class GTSDataExchangeParseException extends GTSDataParseException {
+    private static final long serialVersionUID = -7018527875651263041L;
+
+    public GTSDataExchangeParseException(final ErrorCode errorCode, final int index, final String failedMessage) {
+        super(errorCode, index, failedMessage);
+    }
+
+    public GTSDataExchangeParseException(final ErrorCode errorCode, final int index, final String failedMessage, final Throwable cause) {
+        super(errorCode, index, failedMessage, cause);
+    }
+
+    @Override
+    public final ErrorCode getErrorCode() {
+        return (ErrorCode) super.getErrorCode();
+    }
+
+    public enum ErrorCode implements GTSDataParseException.ErrorCode {
+        UNEXPECTED_END_OF_MESSAGE_LENGTH("Unexpected end of data while parsing message length"), //
+        INVALID_MESSAGE_LENGTH("Invalid message length"), //
+        UNEXPECTED_END_OF_FORMAT_IDENTIFIER("Unexpected end of data while parsing format identifier"), //
+        INVALID_FORMAT_IDENTIFIER("Invalid format identifier");
+
+        private final String messageTemplate;
+
+        ErrorCode(final String message) {
+            this.messageTemplate = message + " starting at index %d";
+        }
+
+        @Override
+        public String message(final int index) {
+            return String.format(Locale.ROOT, messageTemplate, index);
+        }
+    }
+}

--- a/src/main/java/fi/fmi/avi/util/GTSDataExchangeTranscoder.java
+++ b/src/main/java/fi/fmi/avi/util/GTSDataExchangeTranscoder.java
@@ -1,0 +1,390 @@
+package fi.fmi.avi.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.inferred.freebuilder.FreeBuilder;
+
+import fi.fmi.avi.util.GTSDataExchangeParseException.ErrorCode;
+import fi.fmi.avi.util.GTSMeteorologicalMessage.MessageFormat;
+
+public final class GTSDataExchangeTranscoder {
+    /**
+     * Number of characters in message length string.
+     */
+    private static final int MESSAGE_LENGTH_LENGTH = 8;
+    /**
+     * Number of characters in format identifier string.
+     */
+    private static final int FORMAT_IDENTIFIER_LENGTH = 2;
+    /**
+     * Number of characters in message length and format identifier preceding the message.
+     * This is not included in the message length.
+     */
+    private static final int MESSAGE_LENGTH_AND_FORMAT_CHARS_LENGTH = MESSAGE_LENGTH_LENGTH + FORMAT_IDENTIFIER_LENGTH;
+    private static final Set<Protocol> ALL_PROTOCOLS = Collections.unmodifiableSet(EnumSet.allOf(Protocol.class));
+    private static final Pattern MESSAGE_START_PATTERN = Pattern.compile("[0-9]{8}" + Arrays.stream(FormatIdentifier.values())//
+            .map(formatIdentifier -> Pattern.quote(formatIdentifier.getCode() + formatIdentifier.getMessageFormat().getPrefix()))//
+            .collect(Collectors.joining("|", "(", ")")));
+
+    private GTSDataExchangeTranscoder() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Parses provided string for a GTS exchange data content.
+     * Parsing will accept any of supported {@link Protocol protocols}.
+     * The string is read up to message length stated in the beginning of the string. Any remaining part of the string is simply ignored.
+     *
+     * <p>
+     * This method does a string parsing considering the GTS exchange file structure and the signal sequences within it. It does not however look into the
+     * contents of the heading or text part in any way, except for checking that heading does not contain any line break (CR and LF) characters.
+     * The heading and text are only stored as is.
+     * </p>
+     *
+     * @param fileContent
+     *         string to parse
+     *
+     * @return result of parsing
+     */
+    public static ParseResult parse(final String fileContent) {
+        return parse(fileContent, 0, ALL_PROTOCOLS);
+    }
+
+    /**
+     * Parses provided string for a GTS exchange data content.
+     * Parsing will recognize only the provided {@code requiredProtocol}.
+     * The string is read up to message length stated in the beginning of the string. Any remaining part of the string is simply ignored.
+     *
+     * <p>
+     * This method does a string parsing considering the GTS exchange file structure and the signal sequences within it. It does not however look into the
+     * contents of the heading or text part in any way, except for checking that heading does not contain any line break (CR and LF) characters.
+     * The heading and text are only stored as is.
+     * </p>
+     *
+     * @param fileContent
+     *         string to parse
+     * @param requiredProtocol
+     *         required protocol
+     *
+     * @return result of parsing
+     */
+    public static ParseResult parse(final String fileContent, final Protocol requiredProtocol) {
+        requireNonNull(requiredProtocol, "requiredProtocol");
+        return parse(fileContent, 0, Collections.singleton(requiredProtocol));
+    }
+
+    /**
+     * Parses provided string for a GTS exchange data content.
+     * Parsing will start at {@code offset} index and recognize only {@code acceptedProtocols}.
+     * The string is read up to message length stated in the beginning of the string. Any remaining part of the string is simply ignored.
+     *
+     * <p>
+     * This method does a string parsing considering the GTS exchange file structure and the signal sequences within it. It does not however look into the
+     * contents of the heading or text part in any way, except for checking that heading does not contain any line break (CR and LF) characters.
+     * The heading and text are only stored as is.
+     * </p>
+     *
+     * @param fileContent
+     *         string to parse
+     * @param offset
+     *         offset indicating start index of parsing
+     * @param acceptedProtocols
+     *         accepted protocols
+     *
+     * @return result of parsing
+     */
+    public static ParseResult parse(final String fileContent, final int offset, final Set<Protocol> acceptedProtocols) {
+        requireNonNull(fileContent, "fileContent");
+        requireNonNull(acceptedProtocols, "acceptedProtocols");
+        if (offset < 0) {
+            throw new IllegalArgumentException("Offset must not be negative; was: " + offset);
+        }
+        if (acceptedProtocols.isEmpty()) {
+            throw new IllegalArgumentException("acceptedProtocols must not be empty");
+        }
+
+        final ParseResult.Builder builder = ParseResult.builder()//
+                .setStartIndex(offset);
+        int currentIndex = offset;
+
+        // parse message length
+        final int messageLength;
+        try {
+            messageLength = Integer.parseInt(fileContent.substring(currentIndex, currentIndex + MESSAGE_LENGTH_LENGTH));
+        } catch (final IndexOutOfBoundsException e) {
+            return builder.buildError(new GTSDataExchangeParseException(ErrorCode.UNEXPECTED_END_OF_MESSAGE_LENGTH, currentIndex, fileContent, e));
+        } catch (final NumberFormatException e) {
+            return builder.buildError(new GTSDataExchangeParseException(ErrorCode.INVALID_MESSAGE_LENGTH, currentIndex, fileContent, e));
+        }
+        currentIndex += MESSAGE_LENGTH_LENGTH;
+
+        // parse format identifier / protocol and message format
+        final FormatIdentifier formatIdentifier;
+        try {
+            formatIdentifier = FormatIdentifier.fromCode(fileContent.substring(currentIndex, currentIndex + FORMAT_IDENTIFIER_LENGTH));
+        } catch (final IndexOutOfBoundsException e) {
+            return builder.buildError(new GTSDataExchangeParseException(ErrorCode.UNEXPECTED_END_OF_FORMAT_IDENTIFIER, currentIndex, fileContent, e));
+        } catch (final IllegalArgumentException e) {
+            return builder.buildError(new GTSDataExchangeParseException(ErrorCode.INVALID_FORMAT_IDENTIFIER, currentIndex, fileContent));
+        }
+        builder.setProtocol(formatIdentifier.getProtocol());
+        currentIndex += FORMAT_IDENTIFIER_LENGTH;
+
+        // parse message
+        try {
+            builder.setMessage(GTSMeteorologicalMessage.builder()//
+                    .parse(fileContent, currentIndex, messageLength, Collections.singleton(formatIdentifier.getMessageFormat()))//
+                    .build());
+        } catch (final GTSDataParseException e) {
+            return builder.buildError(e);
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Parses the provided string into GTS exchange file templates.
+     * Parsing will accept any of supported {@link Protocol protocols}.
+     * The string can contain multiple bulletins.
+     *
+     * @param fileContent
+     *         file content
+     *
+     * @return a list of parse results
+     */
+    public static List<ParseResult> parseAll(final String fileContent) {
+        return parseAll(fileContent, ALL_PROTOCOLS);
+    }
+
+    /**
+     * Parses the provided string into GTS exchange file templates.
+     * Parsing will recognize only the provided {@code requiredProtocol}.
+     * The string can contain multiple bulletins.
+     *
+     * @param fileContent
+     *         file content
+     * @param requiredProtocol
+     *         required protocol
+     *
+     * @return a list of parse results
+     */
+    public static List<ParseResult> parseAll(final String fileContent, final Protocol requiredProtocol) {
+        requireNonNull(requiredProtocol, "requiredProtocol");
+        return parseAll(fileContent, Collections.singleton(requiredProtocol));
+    }
+
+    /**
+     * Parses the provided string into GTS exchange file templates.
+     * Parsing will recognize only {@code acceptedProtocols}.
+     * The string can contain multiple bulletins.
+     *
+     * @param fileContent
+     *         file content
+     * @param acceptedProtocols
+     *         accepted protocols
+     *
+     * @return a list of parse results
+     */
+    public static List<ParseResult> parseAll(final String fileContent, final Set<Protocol> acceptedProtocols) {
+        requireNonNull(fileContent, "fileContent");
+        requireNonNull(acceptedProtocols, "acceptedProtocols");
+        if (acceptedProtocols.isEmpty()) {
+            throw new IllegalArgumentException("acceptedProtocols must not be empty");
+        }
+
+        final List<ParseResult> results = new ArrayList<>();
+        int nextIndex = 0;
+        while (hasNonWhitespaceContent(fileContent, nextIndex)) {
+            final int currentIndex = nextIndex;
+            final ParseResult result = parse(fileContent, currentIndex, acceptedProtocols);
+            results.add(result);
+            nextIndex = result.getMessage()//
+                    .map(template -> currentIndex + MESSAGE_LENGTH_AND_FORMAT_CHARS_LENGTH + template.getLength())//
+                    .orElseGet(() -> {
+                        final Matcher matcher = MESSAGE_START_PATTERN.matcher(fileContent);
+                        if (matcher.find(currentIndex + 1)) {
+                            return matcher.start();
+                        } else {
+                            return fileContent.length();
+                        }
+                    });
+        }
+        return Collections.unmodifiableList(results);
+    }
+
+    private static boolean hasNonWhitespaceContent(final String fileContent, final int offset) {
+        for (int i = offset; i < fileContent.length(); i++) {
+            if (!Character.isWhitespace(fileContent.charAt(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns the provided {@code message} as string conforming to specified {@code protocol}.
+     *
+     * @param message
+     *         message
+     * @param protocol
+     *         protocol
+     *
+     * @return message as string
+     */
+    public static String toString(final GTSMeteorologicalMessage message, final Protocol protocol) {
+        requireNonNull(message, "message");
+        requireNonNull(protocol, "protocol");
+        return toString(message, protocol, MessageFormat.get(message));
+    }
+
+    /**
+     * Returns the provided {@code message} as string conforming to specified {@code protocol} and {@code messageFormat}.
+     *
+     * @param message
+     *         message
+     * @param protocol
+     *         protocol
+     * @param messageFormat
+     *         message format
+     *
+     * @return message as string
+     *
+     * @throws IllegalArgumentException
+     *         if message cannot be formatted in provided {@code protocol} and {@code messageFormat}
+     */
+    public static String toString(final GTSMeteorologicalMessage message, final Protocol protocol, final MessageFormat messageFormat) {
+        requireNonNull(message, "message");
+        requireNonNull(protocol, "protocol");
+        requireNonNull(messageFormat, "messageFormat");
+        return String.format(Locale.ROOT, "%08d%s%s", //
+                message.getLength(messageFormat), //
+                FormatIdentifier.fromProtocolAndFormat(protocol, messageFormat).getCode(), //
+                message.toString(messageFormat));
+    }
+
+    public enum Protocol {
+        FTP, SOCKET
+    }
+
+    private enum FormatIdentifier {
+        FTP_STANDARD("00", Protocol.FTP, MessageFormat.STANDARD), //
+        FTP_SHORT("01", Protocol.FTP, MessageFormat.SHORT), //
+        SOCKET_ALPHANUMERIC("AN", Protocol.SOCKET, MessageFormat.STANDARD);
+
+        private static final List<FormatIdentifier> VALUES = Collections.unmodifiableList(Arrays.asList(values()));
+
+        private final String code;
+        private final Protocol protocol;
+        private final MessageFormat messageFormat;
+
+        FormatIdentifier(final String code, final Protocol protocol, final MessageFormat messageFormat) {
+            this.protocol = protocol;
+            this.code = code;
+            this.messageFormat = messageFormat;
+        }
+
+        public static FormatIdentifier fromCode(final String code) {
+            for (final FormatIdentifier identifier : VALUES) {
+                if (identifier.getCode().equals(code)) {
+                    return identifier;
+                }
+            }
+            throw new IllegalArgumentException("Unsupported code: " + code);
+        }
+
+        public static FormatIdentifier fromProtocolAndFormat(final Protocol protocol, final MessageFormat messageFormat) {
+            for (final FormatIdentifier identifier : VALUES) {
+                if (identifier.getProtocol() == protocol && identifier.getMessageFormat() == messageFormat) {
+                    return identifier;
+                }
+            }
+            throw new IllegalArgumentException("Unsupported protocol/messageFormat: " + protocol + "/" + messageFormat);
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public Protocol getProtocol() {
+            return protocol;
+        }
+
+        public MessageFormat getMessageFormat() {
+            return messageFormat;
+        }
+    }
+
+    @FreeBuilder
+    public static abstract class ParseResult {
+        ParseResult() {
+        }
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        /**
+         * Returns the start index of parsing.
+         *
+         * @return start index of parsing
+         */
+        public abstract int getStartIndex();
+
+        /**
+         * Returns protocol, when recognized.
+         *
+         * @return protocol or empty Optional
+         */
+        public abstract Optional<Protocol> getProtocol();
+
+        /**
+         * Returns the GTS exchange file template.
+         * When this is present, {@link ParseResult#getError()} will return an empty optional.
+         *
+         * @return GTS exchange file template or an empty Optional
+         */
+        public abstract Optional<GTSMeteorologicalMessage> getMessage();
+
+        /**
+         * Returns the parse error when the message does not meet requirements of WMO Doc. 386 specification or could not be parsed for some other reason.
+         * When this is present, {@link ParseResult#getMessage()} will return an empty optional.
+         *
+         * @return exception providing details of the parse error or an empty optional
+         */
+        public abstract Optional<GTSDataParseException> getError();
+
+        abstract Builder toBuilder();
+
+        static class Builder extends GTSDataExchangeTranscoder_ParseResult_Builder {
+            Builder() {
+            }
+
+            @Override
+            public ParseResult build() {
+                if (getMessage().isPresent() == getError().isPresent()) {
+                    throw new IllegalStateException(
+                            "Message and error are mutually exclusive and cannot be " + (getMessage().isPresent() ? "present" : "empty") + " simultaneously");
+                }
+                return super.build();
+            }
+
+            public ParseResult buildError(final GTSDataParseException error) {
+                return setError(error)//
+                        .clearMessage()//
+                        .build();
+            }
+        }
+    }
+}

--- a/src/main/java/fi/fmi/avi/util/GTSDataParseException.java
+++ b/src/main/java/fi/fmi/avi/util/GTSDataParseException.java
@@ -1,0 +1,39 @@
+package fi.fmi.avi.util;
+
+public class GTSDataParseException extends RuntimeException {
+    private static final long serialVersionUID = 4246342002125774900L;
+
+    private final ErrorCode errorCode;
+    private final int index;
+    private final String failedMessage;
+
+    public GTSDataParseException(final ErrorCode errorCode, final int index, final String failedMessage) {
+        super(errorCode.message(index));
+        this.errorCode = errorCode;
+        this.index = index;
+        this.failedMessage = failedMessage;
+    }
+
+    public GTSDataParseException(final ErrorCode errorCode, final int index, final String failedMessage, final Throwable cause) {
+        this(errorCode, index, failedMessage);
+        initCause(cause);
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public final int getIndex() {
+        return index;
+    }
+
+    public final String getFailedMessage() {
+        return failedMessage;
+    }
+
+    public interface ErrorCode {
+        String name();
+
+        String message(final int index);
+    }
+}

--- a/src/main/java/fi/fmi/avi/util/GTSExchangeFileParseException.java
+++ b/src/main/java/fi/fmi/avi/util/GTSExchangeFileParseException.java
@@ -4,6 +4,12 @@ import java.util.Locale;
 
 import org.inferred.freebuilder.shaded.com.google.common.annotations.VisibleForTesting;
 
+/**
+ * Deprecated.
+ *
+ * @deprecated in favor of {@link GTSDataParseException} and subclasses.
+ */
+@Deprecated
 public class GTSExchangeFileParseException extends RuntimeException {
     private static final long serialVersionUID = 7637916048067538148L;
 
@@ -11,6 +17,7 @@ public class GTSExchangeFileParseException extends RuntimeException {
     private final int index;
     private final String failedMessage;
 
+    @Deprecated
     public GTSExchangeFileParseException(final ParseErrorCode errorCode, final int index, final String failedMessage) {
         super(errorCode.getMessage(index));
         this.errorCode = errorCode;
@@ -18,6 +25,7 @@ public class GTSExchangeFileParseException extends RuntimeException {
         this.failedMessage = failedMessage;
     }
 
+    @Deprecated
     public GTSExchangeFileParseException(final ParseErrorCode errorCode, final int index, final String failedMessage, final Throwable cause) {
         super(errorCode.getMessage(index), cause);
         this.errorCode = errorCode;
@@ -25,18 +33,22 @@ public class GTSExchangeFileParseException extends RuntimeException {
         this.failedMessage = failedMessage;
     }
 
+    @Deprecated
     public ParseErrorCode getErrorCode() {
         return errorCode;
     }
 
+    @Deprecated
     public int getIndex() {
         return index;
     }
 
+    @Deprecated
     public String getFailedMessage() {
         return failedMessage;
     }
 
+    @Deprecated
     public enum ParseErrorCode {
         UNEXPECTED_END_OF_MESSAGE_LENGTH("Unexpected end of data while parsing message length"), //
         INVALID_MESSAGE_LENGTH("Invalid message length"), //

--- a/src/main/java/fi/fmi/avi/util/GTSExchangeFileTemplate.java
+++ b/src/main/java/fi/fmi/avi/util/GTSExchangeFileTemplate.java
@@ -1,18 +1,33 @@
 package fi.fmi.avi.util;
 
-import fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter;
-import fi.fmi.avi.util.GTSExchangeFileParseException.ParseErrorCode;
-import org.inferred.freebuilder.FreeBuilder;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.END_OF_TEXT;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.START_OF_HEADING;
+import static java.util.Objects.requireNonNull;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.*;
-import static java.util.Objects.requireNonNull;
+import org.inferred.freebuilder.FreeBuilder;
 
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter;
+import fi.fmi.avi.util.GTSExchangeFileParseException.ParseErrorCode;
+
+/**
+ * Deprecated.
+ *
+ * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+ */
+@Deprecated
 @FreeBuilder
 public abstract class GTSExchangeFileTemplate implements Serializable {
     public static final String STARTING_LINE_PREFIX = stringOf(START_OF_HEADING, CARRIAGE_RETURN, CARRIAGE_RETURN, LINE_FEED);
@@ -40,56 +55,86 @@ public abstract class GTSExchangeFileTemplate implements Serializable {
                 .collect(Collectors.joining());
     }
 
+    /**
+     * Deprecated.
+     *
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+     */
+    @Deprecated
     public static Builder builder() {
         return new Builder();
     }
 
     /**
+     * Deprecated.
      * Parses the provided string into a GTS exchange file template.
      *
-     * @param fileContent file content
+     * @param fileContent
+     *         file content
+     *
      * @return parsed GTS exchange file template
+     *
      * @see Builder#parse(String)
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
      */
+    @Deprecated
     public static GTSExchangeFileTemplate parse(final String fileContent) {
         requireNonNull(fileContent, "fileContent");
         return builder().parse(fileContent).build();
     }
 
     /**
+     * Deprecated.
      * Parses the provided string into a GTS exchange file template.
      * The string is interpreted as a bulletin heading and text content.
      *
-     * @param fileContent file content
+     * @param fileContent
+     *         file content
+     *
      * @return parsed GTS exchange file template
+     *
      * @see Builder#parseHeadingAndText(String)
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
      */
+    @Deprecated
     public static GTSExchangeFileTemplate parseHeadingAndText(final String fileContent) {
         requireNonNull(fileContent, "fileContent");
         return builder().parseHeadingAndText(fileContent).build();
     }
 
     /**
+     * Deprecated.
      * Parses the provided string into a GTS exchange file template.
      * The string is leniently interpreted as a bulletin heading and text content.
      *
-     * @param data data to parse
+     * @param data
+     *         data to parse
+     *
      * @return parsed GTS exchange file template
+     *
      * @see Builder#parseHeadingAndTextLenient(String)
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
      */
+    @Deprecated
     public static GTSExchangeFileTemplate parseHeadingAndTextLenient(final String data) {
         requireNonNull(data, "data");
         return builder().parseHeadingAndTextLenient(data).build();
     }
 
     /**
+     * Deprecated.
      * Parses the provided string into GTS exchange file templates.
      * The string can contain multiple bulletins.
      *
-     * @param fileContent file content
+     * @param fileContent
+     *         file content
+     *
      * @return a list of parse results
+     *
      * @see Builder#parse(String)
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
      */
+    @Deprecated
     public static List<ParseResult> parseAll(final String fileContent) {
         requireNonNull(fileContent, "fileContent");
         final List<ParseResult> results = new ArrayList<>();
@@ -144,6 +189,12 @@ public abstract class GTSExchangeFileTemplate implements Serializable {
         return String.format(Locale.ROOT, "Illegal formatIdentifier: <%02d>", formatIdentifier);
     }
 
+    /**
+     * Deprecated.
+     *
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+     */
+    @Deprecated
     public int getMessageLength() {
         final int formatIdentifier = getFormatIdentifier();
         if (formatIdentifier == MESSAGE_FORMAT_LONG) {
@@ -164,31 +215,77 @@ public abstract class GTSExchangeFileTemplate implements Serializable {
         }
     }
 
+    /**
+     * Deprecated.
+     *
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+     */
+    @Deprecated
     public int getFormatIdentifier() {
         return getTransmissionSequenceNumber().isEmpty() ? MESSAGE_FORMAT_SHORT : MESSAGE_FORMAT_LONG;
     }
 
+    /**
+     * Deprecated.
+     *
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+     */
+    @Deprecated
     public abstract String getTransmissionSequenceNumber();
 
+    /**
+     * Deprecated.
+     *
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+     */
+    @Deprecated
     public Optional<Integer> getTransmissionSequenceNumberAsInt() {
         return transmissionSequenceNumberToInt(getTransmissionSequenceNumber());
     }
 
+    /**
+     * Deprecated.
+     *
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+     */
+    @Deprecated
     public abstract String getHeading();
 
     /**
+     * Deprecated.
      * Returns message text part without initial {@link #TEXT_PREFIX}.
      *
      * @return message text part without initial {@link #TEXT_PREFIX}
+     *
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
      */
+    @Deprecated
     public abstract String getText();
 
+    /**
+     * Deprecated.
+     *
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+     */
+    @Deprecated
     public abstract Builder toBuilder();
 
+    /**
+     * Deprecated.
+     *
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+     */
+    @Deprecated
     public String toHeadingAndTextString() {
         return getHeading() + TEXT_PREFIX + getText();
     }
 
+    /**
+     * Deprecated.
+     *
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+     */
+    @Deprecated
     public String toString() {
         final int formatIdentifier = getFormatIdentifier();
         if (formatIdentifier == MESSAGE_FORMAT_LONG) {
@@ -215,6 +312,12 @@ public abstract class GTSExchangeFileTemplate implements Serializable {
         }
     }
 
+    /**
+     * Deprecated.
+     *
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+     */
+    @Deprecated
     public static class Builder extends GTSExchangeFileTemplate_Builder {
         private static final int MESSAGE_LENGTH_LENGTH = 8;
         private static final int FORMAT_IDENTIFIER_LENGTH = 2;
@@ -236,6 +339,7 @@ public abstract class GTSExchangeFileTemplate implements Serializable {
         }
 
         /**
+         * Deprecated.
          * Parses provided string for a GTS exchange file content and populates this builder with parsed message.
          * The string is read up to message length stated in the beginning of the string. Any remaining part of the string is simply ignored.
          *
@@ -245,15 +349,27 @@ public abstract class GTSExchangeFileTemplate implements Serializable {
          * The heading and text are only stored as is.
          * </p>
          *
-         * @param fileContent string to parse
+         * @param fileContent
+         *         string to parse
+         *
          * @return this builder
-         * @throws GTSExchangeFileParseException if provided {@code message} cannot be parsed or does not meet requirements of WMO Doc. 386 specification.
+         *
+         * @throws GTSExchangeFileParseException
+         *         if provided {@code message} cannot be parsed or does not meet requirements of WMO Doc. 386 specification.
+         * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
          */
+        @Deprecated
         public Builder parse(final String fileContent) {
             requireNonNull(fileContent, "message");
             return parse(fileContent, 0);
         }
 
+        /**
+         * Deprecated.
+         *
+         * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+         */
+        @Deprecated
         public Builder parse(final String fileContent, final int offset) {
             // parse message length
             int currentIndex = offset;
@@ -332,6 +448,7 @@ public abstract class GTSExchangeFileTemplate implements Serializable {
         }
 
         /**
+         * Deprecated.
          * Parses provided string for bulletin heading and text content and populates this builder with parsed headingAndText.
          * This parsing method is strict. The start of provided {@code headingAndText} is until {@link #TEXT_PREFIX}
          * is interpreted as the heading. It must not contain any other line break (CR and LF) characters. The remaining part of the {@code headingAndText} is
@@ -342,10 +459,16 @@ public abstract class GTSExchangeFileTemplate implements Serializable {
          * builder is not modified.
          * </p>
          *
-         * @param headingAndText string to parse
+         * @param headingAndText
+         *         string to parse
+         *
          * @return this builder
-         * @throws GTSExchangeFileParseException if provided {@code headingAndText} cannot be parsed or does not meet requirements of WMO Doc. 386 specification. This builder is not modified.
+         *
+         * @throws GTSExchangeFileParseException
+         *         if provided {@code headingAndText} cannot be parsed or does not meet requirements of WMO Doc. 386 specification. This builder is not modified.
+         * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
          */
+        @Deprecated
         public Builder parseHeadingAndText(final String headingAndText) {
             requireNonNull(headingAndText, "headingAndText");
             return parseHeadingAndText(headingAndText, 0, headingAndText.length());
@@ -375,6 +498,7 @@ public abstract class GTSExchangeFileTemplate implements Serializable {
         }
 
         /**
+         * Deprecated.
          * Parses provided string for bulletin heading and text content and populates this builder with parsed headingAndText.
          * This parsing method is lenient. The first line of provided {@code headingAndText} is interpreted as the heading. Then any sequence of CR and LF characters
          * is skipped, and the remaining part of the {@code headingAndText} string is interpreted as text content as is. If provided {@code headingAndText} contains no CR or LF
@@ -385,9 +509,14 @@ public abstract class GTSExchangeFileTemplate implements Serializable {
          * Note that this method does not affect any other property of this builder than {@code heading} and {@code text}.
          * </p>
          *
-         * @param headingAndText string to parse
+         * @param headingAndText
+         *         string to parse
+         *
          * @return this builder
+         *
+         * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
          */
+        @Deprecated
         public Builder parseHeadingAndTextLenient(final String headingAndText) {
             requireNonNull(headingAndText, "headingAndText");
             final String[] splitHeadingAndText = ANY_SEQUENCE_OF_LINE_BREAKS.split(headingAndText, 2);
@@ -395,18 +524,42 @@ public abstract class GTSExchangeFileTemplate implements Serializable {
                     .setText(splitHeadingAndText.length > 1 ? splitHeadingAndText[1] : "");
         }
 
+        /**
+         * Deprecated.
+         *
+         * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+         */
+        @Deprecated
         public Builder clearTransmissionSequenceNumber() {
             return setTransmissionSequenceNumber("");
         }
 
+        /**
+         * Deprecated.
+         *
+         * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+         */
+        @Deprecated
         public Optional<Integer> getTransmissionSequenceNumberAsInt() {
             return transmissionSequenceNumberToInt(getTransmissionSequenceNumber());
         }
 
+        /**
+         * Deprecated.
+         *
+         * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+         */
+        @Deprecated
         public Builder setTransmissionSequenceNumberAsInt(final int number) {
             return setTransmissionSequenceNumberAsInt(number, 3);
         }
 
+        /**
+         * Deprecated.
+         *
+         * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+         */
+        @Deprecated
         public Builder setTransmissionSequenceNumberAsInt(final int number, final int numberOfDigits) {
             if (number < 0) {
                 throw new IllegalArgumentException("number is negative: " + number);
@@ -422,29 +575,55 @@ public abstract class GTSExchangeFileTemplate implements Serializable {
         }
     }
 
+    /**
+     * Deprecated.
+     *
+     * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+     */
+    @Deprecated
     @FreeBuilder
     public static abstract class ParseResult {
         ParseResult() {
         }
 
+        /**
+         * Deprecated.
+         *
+         * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+         */
+        @Deprecated
         public abstract int getStartIndex();
 
         /**
+         * Deprecated.
          * Returns the GTS exchange file template.
          * When this is present, {@link ParseResult#getError()} will return an empty optional.
          *
          * @return GTS exchange file template or an empty Optional
+         *
+         * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
          */
+        @Deprecated
         public abstract Optional<GTSExchangeFileTemplate> getResult();
 
         /**
+         * Deprecated.
          * Returns the parse error.
          * When this is present, {@link ParseResult#getResult()} will return an empty optional.
          *
          * @return exception providing details of the parse error or an empty optional
+         *
+         * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
          */
+        @Deprecated
         public abstract Optional<GTSExchangeFileParseException> getError();
 
+        /**
+         * Deprecated.
+         *
+         * @deprecated in favor of {@link GTSDataExchangeTranscoder} and {@link GTSMeteorologicalMessage}.
+         */
+        @Deprecated
         public static class Builder extends GTSExchangeFileTemplate_ParseResult_Builder {
             Builder() {
             }

--- a/src/main/java/fi/fmi/avi/util/GTSMeteorologicalMessage.java
+++ b/src/main/java/fi/fmi/avi/util/GTSMeteorologicalMessage.java
@@ -1,0 +1,661 @@
+package fi.fmi.avi.util;
+
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.END_OF_TEXT;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.START_OF_HEADING;
+import static java.util.Objects.requireNonNull;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.inferred.freebuilder.FreeBuilder;
+
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter;
+import fi.fmi.avi.util.GTSMeteorologicalMessageParseException.ErrorCode;
+
+@FreeBuilder
+public abstract class GTSMeteorologicalMessage implements Serializable {
+    public static final String STARTING_LINE_PREFIX = stringOf(START_OF_HEADING, CARRIAGE_RETURN, CARRIAGE_RETURN, LINE_FEED);
+    public static final String HEADING_PREFIX = stringOf(CARRIAGE_RETURN, CARRIAGE_RETURN, LINE_FEED);
+    public static final String TEXT_PREFIX = stringOf(CARRIAGE_RETURN, CARRIAGE_RETURN, LINE_FEED);
+    public static final String END_OF_MESSAGE_SIGNALS = stringOf(CARRIAGE_RETURN, CARRIAGE_RETURN, LINE_FEED, END_OF_TEXT);
+
+    private static final long serialVersionUID = 9215784958510861534L;
+
+    static String stringOf(final MeteorologicalBulletinSpecialCharacter... specialCharacters) {
+        return Arrays.stream(specialCharacters)//
+                .map(MeteorologicalBulletinSpecialCharacter::getContent)//
+                .collect(Collectors.joining());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Parses the provided string in {@link MessageFormat#STANDARD standard} or {@link MessageFormat#SHORT short} format into a GTS meteorological message.
+     *
+     * @param content
+     *         alphanumerical GTS meteorological message
+     *
+     * @return parsed GTS meteorological message
+     *
+     * @throws GTSMeteorologicalMessageParseException
+     *         if provided {@code message} cannot be parsed or does not meet requirements of WMO Doc. 386 specification.
+     * @see Builder#parse(String)
+     */
+    public static GTSMeteorologicalMessage parse(final String content) {
+        return builder().parse(content).build();
+    }
+
+    /**
+     * Parses the provided string in format specified by {@code requiredFormat} into a GTS meteorological message.
+     *
+     * @param content
+     *         alphanumerical GTS meteorological message
+     *
+     * @return parsed GTS meteorological message
+     *
+     * @throws GTSMeteorologicalMessageParseException
+     *         if provided {@code message} cannot be parsed or does not meet requirements of WMO Doc. 386 specification.
+     * @see Builder#parse(String, MessageFormat)
+     */
+    public static GTSMeteorologicalMessage parse(final String content, final MessageFormat requiredFormat) {
+        return builder().parse(content, requiredFormat).build();
+    }
+
+    /**
+     * Parses the provided string in any format specified by {@code acceptedFormats} into a GTS meteorological message.
+     *
+     * @param content
+     *         alphanumerical GTS meteorological message
+     *
+     * @return parsed GTS meteorological message
+     *
+     * @throws GTSMeteorologicalMessageParseException
+     *         if provided {@code message} cannot be parsed or does not meet requirements of WMO Doc. 386 specification.
+     * @see Builder#parse(String, Set)
+     */
+    public static GTSMeteorologicalMessage parse(final String content, final Set<MessageFormat> acceptedFormats) {
+        return builder().parse(content, acceptedFormats).build();
+    }
+
+    /**
+     * Parses the provided string into a GTS meteorological message.
+     * The string is leniently interpreted as a bulletin heading and text content.
+     *
+     * @param content
+     *         bulletin heading and text content
+     *
+     * @return parsed GTS meteorological message
+     *
+     * @see Builder#parseHeadingAndTextLenient(String)
+     */
+    public static GTSMeteorologicalMessage parseHeadingAndTextLenient(final String content) {
+        requireNonNull(content, "content");
+        return builder().parseHeadingAndTextLenient(content).build();
+    }
+
+    private static Optional<Integer> transmissionSequenceNumberToInt(final String transmissionSequenceNumber) {
+        return Optional.of(transmissionSequenceNumber)//
+                .filter(seqNo -> !seqNo.isEmpty())//
+                .map(seqNo -> {
+                    try {
+                        return Integer.parseInt(seqNo);
+                    } catch (final NumberFormatException ignored) {
+                        return null;
+                    }
+                });
+    }
+
+    /**
+     * Returns the message length.
+     *
+     * @return message length
+     */
+    public int getLength() {
+        return getLength(MessageFormat.get(this));
+    }
+
+    /**
+     * Returns the message length in provided {@code messageFormat}.
+     *
+     * @param messageFormat
+     *         message format
+     *
+     * @return length in provided {@code messageFormat}
+     *
+     * @throws IllegalArgumentException
+     *         if message does not {@link #supports(MessageFormat) support} the provided {@code messageFormat}
+     */
+    public int getLength(final MessageFormat messageFormat) {
+        requireNonNull(messageFormat, "messageFormat");
+        return messageFormat.length(this);
+    }
+
+    /**
+     * Returns transmission sequence number as a string, or empty string if not present.
+     *
+     * @return transmission sequence number as a string, or empty string if not present.
+     */
+    public abstract String getTransmissionSequenceNumber();
+
+    /**
+     * Returns transmission sequence number as an integer, or empty if not present.
+     *
+     * @return transmission sequence number as an integer, or empty if not present.
+     */
+    public Optional<Integer> getTransmissionSequenceNumberAsInt() {
+        return transmissionSequenceNumberToInt(getTransmissionSequenceNumber());
+    }
+
+    /**
+     * Returns message heading without initial {@link #HEADING_PREFIX}.
+     *
+     * @return message heading without initial {@link #HEADING_PREFIX}
+     */
+    public abstract String getHeading();
+
+    /**
+     * Returns message text part without initial {@link #TEXT_PREFIX}.
+     *
+     * @return message text part without initial {@link #TEXT_PREFIX}
+     */
+    public abstract String getText();
+
+    public abstract Builder toBuilder();
+
+    public boolean supports(final MessageFormat messageFormat) {
+        requireNonNull(messageFormat, "messageFormat");
+        return messageFormat.supports(this);
+    }
+
+    /**
+     * Returns this meteorological message formatted as string.
+     *
+     * @return this meteorological message formatted as string
+     */
+    public String toString() {
+        return toString(MessageFormat.get(this));
+    }
+
+    /**
+     * Returns this meteorological message as string formatted in provided {@code messageFormat}.
+     *
+     * @param messageFormat
+     *         message format
+     *
+     * @return this meteorological message as string formatted in provided {@code messageFormat}
+     *
+     * @throws IllegalArgumentException
+     *         if message does not {@link #supports(MessageFormat) support} the provided {@code messageFormat}
+     */
+    public String toString(final MessageFormat messageFormat) {
+        requireNonNull(messageFormat, "messageFormat");
+        final StringBuilder builder = new StringBuilder();
+        messageFormat.appendTo(builder, this);
+        return builder.toString();
+    }
+
+    public enum MessageFormat {
+        /**
+         * Standard GTS meteorological message, consisting of starting line, heading and text.
+         * File format identifier {@code 00}.
+         */
+        STANDARD(STARTING_LINE_PREFIX) {
+            @Override
+            boolean supports(final GTSMeteorologicalMessage message) {
+                return !message.getTransmissionSequenceNumber().isEmpty();
+            }
+
+            @Override
+            int length(final GTSMeteorologicalMessage message) {
+                checkIsSupported(message);
+                return STARTING_LINE_PREFIX.length() //
+                        + message.getTransmissionSequenceNumber().length() //
+                        + SHORT.length(message) //
+                        + END_OF_MESSAGE_SIGNALS.length();
+            }
+
+            @Override
+            void appendTo(final StringBuilder builder, final GTSMeteorologicalMessage message) {
+                checkIsSupported(message);
+                builder//
+                        .append(STARTING_LINE_PREFIX)//
+                        .append(message.getTransmissionSequenceNumber());
+                SHORT.appendTo(builder, message);
+                builder.append(END_OF_MESSAGE_SIGNALS);
+            }
+        }, //
+        /**
+         * A shortened GTS meteorological message, missing starting line and end-of-message.
+         * File format identifier {@code 01}.
+         */
+        SHORT(HEADING_PREFIX) {
+            @Override
+            boolean supports(final GTSMeteorologicalMessage message) {
+                requireNonNull(message, "message");
+                return true;
+            }
+
+            @Override
+            int length(final GTSMeteorologicalMessage message) {
+                return HEADING_PREFIX.length() //
+                        + HEADING_AND_TEXT.length(message);
+            }
+
+            @Override
+            void appendTo(final StringBuilder builder, final GTSMeteorologicalMessage message) {
+                builder.append(HEADING_PREFIX);
+                HEADING_AND_TEXT.appendTo(builder, message);
+            }
+        }, //
+        /**
+         * A non-standard message format consisting of only heading and text separated by {@link #TEXT_PREFIX}.
+         */
+        HEADING_AND_TEXT("") {
+            @Override
+            boolean supports(final GTSMeteorologicalMessage message) {
+                requireNonNull(message, "message");
+                return true;
+            }
+
+            @Override
+            int length(final GTSMeteorologicalMessage message) {
+                return message.getHeading().length() //
+                        + TEXT_PREFIX.length() //
+                        + message.getText().length();
+            }
+
+            @Override
+            void appendTo(final StringBuilder builder, final GTSMeteorologicalMessage message) {
+                builder.append(message.getHeading())//
+                        .append(TEXT_PREFIX)//
+                        .append(message.getText());
+            }
+        };
+
+        private final String prefix;
+
+        MessageFormat(final String prefix) {
+            this.prefix = prefix;
+        }
+
+        static MessageFormat get(final GTSMeteorologicalMessage message) {
+            requireNonNull(message, "message");
+            return message.getTransmissionSequenceNumber().isEmpty() ? SHORT : STANDARD;
+        }
+
+        String getPrefix() {
+            return prefix;
+        }
+
+        void checkIsSupported(final GTSMeteorologicalMessage message) {
+            requireNonNull(message, "message");
+            if (!supports(message)) {
+                throw new IllegalArgumentException("Unsupported MessageFormat: " + this);
+            }
+        }
+
+        abstract boolean supports(final GTSMeteorologicalMessage message);
+
+        abstract int length(final GTSMeteorologicalMessage message);
+
+        abstract void appendTo(final StringBuilder builder, final GTSMeteorologicalMessage message);
+    }
+
+    private static class ParsingContext {
+        private final String content;
+        private final Set<MessageFormat> acceptedFormats;
+        private int currentIndex;
+
+        ParsingContext(final String content, final Set<MessageFormat> acceptedFormats, final int offset) {
+            this.content = requireNonNull(content, "content");
+            this.acceptedFormats = requireNonNull(acceptedFormats, "acceptedFormats");
+            this.currentIndex = offset;
+            if (acceptedFormats.isEmpty()) {
+                throw new IllegalArgumentException("acceptedFormats must not be empty");
+            }
+        }
+
+        public String getContent() {
+            return content;
+        }
+
+        public int getCurrentIndex() {
+            return currentIndex;
+        }
+
+        public void setCurrentIndex(final int currentIndex) {
+            this.currentIndex = currentIndex;
+        }
+
+        public void increaseCurrentIndex(final int increase) {
+            currentIndex += increase;
+        }
+
+        public boolean accepted(final MessageFormat messageFormat) {
+            return acceptedFormats.contains(messageFormat);
+        }
+
+        public boolean noneAccepted(final MessageFormat... messageFormats) {
+            for (final MessageFormat messageFormat : messageFormats) {
+                if (accepted(messageFormat)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    public static class Builder extends GTSMeteorologicalMessage_Builder {
+        private static final Set<MessageFormat> ALL_MESSAGE_FORMATS = Collections.unmodifiableSet(EnumSet.allOf(MessageFormat.class));
+        private static final Pattern ANY_SEQUENCE_OF_LINE_BREAKS = Pattern.compile(
+                String.format(Locale.ROOT, "[%s]+", Pattern.quote(stringOf(CARRIAGE_RETURN, LINE_FEED))));
+
+        Builder() {
+            setTransmissionSequenceNumber("");
+        }
+
+        private static int indexOfAnyLineBreak(final CharSequence content) {
+            final Matcher matcher = ANY_SEQUENCE_OF_LINE_BREAKS.matcher(content);
+            if (matcher.find()) {
+                return matcher.start();
+            } else {
+                return -1;
+            }
+        }
+
+        /**
+         * Parses provided string of GTS meteorological message content in {@link MessageFormat#STANDARD standard} or {@link MessageFormat#SHORT short} format
+         * and populates this builder with parsed message.
+         * Parsing will accept any of supported {@link MessageFormat message formats}.
+         *
+         * <p>
+         * If the parsed message is missing the transmission sequence number, the {@link #setTransmissionSequenceNumber(String)} property will not be changed.
+         * In case you want to ensure transmission sequence number is set or reset correctly, invoke {@link #clearTransmissionSequenceNumber()} before this
+         * method.
+         * </p>
+         *
+         * <p>
+         * This method does a string parsing considering the GTS meteorological message structure and the signal sequences within it. It does not however
+         * look into the contents of the heading or text part in any way, except for checking that heading does not contain any line break (CR and LF)
+         * characters. The heading and text are stored in the data structure as is.
+         * </p>
+         *
+         * @param content
+         *         GTS meteorological message string to parse
+         *
+         * @return this builder
+         *
+         * @throws GTSMeteorologicalMessageParseException
+         *         if provided {@code message} cannot be parsed or does not meet requirements of WMO Doc. 386 specification.
+         */
+        public Builder parse(final String content) {
+            return parse(content, ALL_MESSAGE_FORMATS);
+        }
+
+        /**
+         * Parses provided string of GTS meteorological message content in format specified by {@code requiredFormat}
+         * and populates this builder with parsed message.
+         * Parsing will recognize only the provided {@code requiredFormat}.
+         *
+         * <p>
+         * If the parsed message is missing the transmission sequence number, the {@link #setTransmissionSequenceNumber(String)} property will not be changed.
+         * In case you want to ensure transmission sequence number is set or reset correctly, invoke {@link #clearTransmissionSequenceNumber()} before this
+         * method.
+         * </p>
+         *
+         * <p>
+         * This method does a string parsing considering the GTS meteorological message structure and the signal sequences within it. It does not however
+         * look into the contents of the heading or text part in any way, except for checking that heading does not contain any line break (CR and LF)
+         * characters. The heading and text are stored in the data structure as is.
+         * </p>
+         *
+         * @param content
+         *         GTS meteorological message string to parse
+         * @param requiredFormat
+         *         message format to parse as
+         *
+         * @return this builder
+         *
+         * @throws GTSMeteorologicalMessageParseException
+         *         if provided {@code message} cannot be parsed or does not meet requirements of WMO Doc. 386 specification.
+         */
+        public Builder parse(final String content, final MessageFormat requiredFormat) {
+            requireNonNull(requiredFormat, "requiredFormat");
+            return parse(content, Collections.singleton(requiredFormat));
+        }
+
+        /**
+         * Parses provided string of GTS meteorological message content in any format specified by {@code acceptedFormats}
+         * and populates this builder with parsed message.
+         * Parsing will recognize only {@code acceptedFormats}.
+         *
+         * <p>
+         * If the parsed message is missing the transmission sequence number, the {@link #setTransmissionSequenceNumber(String)} property will not be changed.
+         * In case you want to ensure transmission sequence number is set or reset correctly, invoke {@link #clearTransmissionSequenceNumber()} before this
+         * method.
+         * </p>
+         *
+         * <p>
+         * This method does a string parsing considering the GTS meteorological message structure and the signal sequences within it. It does not however
+         * look into the contents of the heading or text part in any way, except for checking that heading does not contain any line break (CR and LF)
+         * characters. The heading and text are stored in the data structure as is.
+         * </p>
+         *
+         * @param content
+         *         GTS meteorological message string to parse
+         * @param acceptedFormats
+         *         accepted message formats
+         *
+         * @return this builder
+         *
+         * @throws GTSMeteorologicalMessageParseException
+         *         if provided {@code message} cannot be parsed or does not meet requirements of WMO Doc. 386 specification.
+         */
+        public Builder parse(final String content, final Set<MessageFormat> acceptedFormats) {
+            requireNonNull(content, "content");
+            return parse(content, 0, content.length(), acceptedFormats);
+        }
+
+        /**
+         * Parses specified part of provided GTS meteorological message string in any format specified by {@code acceptedFormats}
+         * and populates this builder with parsed message.
+         * Parsing will start at {@code offset} index for provided {@code messageLength} and recognize only {@code acceptedProtocols}.
+         *
+         * <p>
+         * If the parsed message is missing the transmission sequence number, the {@link #setTransmissionSequenceNumber(String)} property will not be changed.
+         * In case you want to ensure transmission sequence number is set or reset correctly, invoke {@link #clearTransmissionSequenceNumber()} before this
+         * method.
+         * </p>
+         *
+         * <p>
+         * This method does a string parsing considering the GTS meteorological message structure and the signal sequences within it. It does not however
+         * look into the contents of the heading or text part in any way, except for checking that heading does not contain any line break (CR and LF)
+         * characters. The heading and text are stored in the data structure as is.
+         * </p>
+         *
+         * @param content
+         *         GTS meteorological message string to parse
+         * @param offset
+         *         offset index to start parsing from
+         * @param messageLength
+         *         length to parse starting from offset index
+         * @param acceptedFormats
+         *         accepted message formats
+         *
+         * @return this builder
+         *
+         * @throws GTSMeteorologicalMessageParseException
+         *         if provided {@code message} cannot be parsed or does not meet requirements of WMO Doc. 386 specification.
+         */
+        public Builder parse(final String content, final int offset, final int messageLength, final Set<MessageFormat> acceptedFormats) {
+            requireNonNull(content, "content");
+            requireNonNull(acceptedFormats, "acceptedFormats");
+            return parse(new ParsingContext(content, acceptedFormats, offset), messageLength);
+        }
+
+        private Builder parse(final ParsingContext context, final int messageLength) {
+            final int messageEndIndex = context.getCurrentIndex() + messageLength;
+            final String transmissionSequenceNumber = parseTransmissionSequenceNumber(context);
+            final boolean standardMessageFormat = !transmissionSequenceNumber.isEmpty();
+            forwardHeadingPrefix(context, standardMessageFormat);
+            final int textEndIndex = lookupTextEndIndex(context.getContent(), messageEndIndex, standardMessageFormat);
+            final String heading = parseHeading(context, textEndIndex);
+            final String text = parseText(context, textEndIndex);
+
+            setHeading(heading);
+            setText(text);
+            if (standardMessageFormat) {
+                setTransmissionSequenceNumber(transmissionSequenceNumber);
+            }
+            return this;
+        }
+
+        private String parseTransmissionSequenceNumber(final ParsingContext context) {
+            final String content = context.getContent();
+            final String transmissionSequenceNumber;
+            if (content.startsWith(STARTING_LINE_PREFIX, context.getCurrentIndex())) {
+                if (!context.accepted(MessageFormat.STANDARD)) {
+                    throw new GTSMeteorologicalMessageParseException(ErrorCode.UNEXPECTED_STARTING_LINE_PREFIX, context.getCurrentIndex(), content);
+                }
+                context.increaseCurrentIndex(STARTING_LINE_PREFIX.length());
+                final int seqNoEndIndex = content.indexOf(HEADING_PREFIX, context.getCurrentIndex());
+                if (seqNoEndIndex < 0) {
+                    throw new GTSMeteorologicalMessageParseException(ErrorCode.UNEXPECTED_END_OF_TRANSMISSION_SEQUENCE_NUMBER, context.getCurrentIndex(),
+                            content);
+                }
+                transmissionSequenceNumber = content.substring(context.getCurrentIndex(), seqNoEndIndex);
+                final int lineBreakIndex = indexOfAnyLineBreak(transmissionSequenceNumber);
+                if (lineBreakIndex >= 0) {
+                    throw new GTSMeteorologicalMessageParseException(ErrorCode.UNEXPECTED_LINE_BREAKS_IN_TRANSMISSION_SEQUENCE_NUMBER,
+                            context.getCurrentIndex() + lineBreakIndex, content);
+                }
+                context.setCurrentIndex(seqNoEndIndex);
+            } else {
+                if (context.accepted(MessageFormat.STANDARD) && context.noneAccepted(MessageFormat.SHORT, MessageFormat.HEADING_AND_TEXT)) {
+                    throw new GTSMeteorologicalMessageParseException(ErrorCode.MISSING_STARTING_LINE_PREFIX, context.getCurrentIndex(), content);
+                }
+                transmissionSequenceNumber = "";
+            }
+            return transmissionSequenceNumber;
+        }
+
+        private void forwardHeadingPrefix(final ParsingContext context, final boolean standardMessageFormat) {
+            if (context.content.startsWith(HEADING_PREFIX, context.getCurrentIndex())) {
+                if (!standardMessageFormat && !context.accepted(MessageFormat.SHORT)) {
+                    throw new GTSMeteorologicalMessageParseException(ErrorCode.UNEXPECTED_HEADING_PREFIX, context.getCurrentIndex(), context.getContent());
+                }
+                context.increaseCurrentIndex(HEADING_PREFIX.length());
+            } else if (!context.accepted(MessageFormat.HEADING_AND_TEXT)) {
+                if (!standardMessageFormat && context.accepted(MessageFormat.STANDARD)) {
+                    throw new GTSMeteorologicalMessageParseException(ErrorCode.MISSING_STARTING_LINE_PREFIX, context.getCurrentIndex(), context.getContent());
+                } else if (context.accepted(MessageFormat.STANDARD) || context.accepted(MessageFormat.SHORT)) {
+                    throw new GTSMeteorologicalMessageParseException(ErrorCode.MISSING_HEADING_PREFIX, context.getCurrentIndex(), context.getContent());
+                }
+            }
+        }
+
+        private int lookupTextEndIndex(final String content, final int messageEndIndex, final boolean standardMessageFormat) {
+            final int textEndIndex;
+            if (standardMessageFormat) {
+                textEndIndex = messageEndIndex - END_OF_MESSAGE_SIGNALS.length();
+                if (!content.startsWith(END_OF_MESSAGE_SIGNALS, textEndIndex)) {
+                    throw new GTSMeteorologicalMessageParseException(ErrorCode.MISSING_END_OF_MESSAGE_SIGNALS, textEndIndex, content);
+                }
+            } else {
+                textEndIndex = messageEndIndex;
+            }
+            return textEndIndex;
+        }
+
+        private String parseHeading(final ParsingContext context, final int endIndex) {
+            final String content = context.getContent();
+            final String truncatedFileContent = content.substring(0, Math.min(content.length(), context.getCurrentIndex() + endIndex));
+            final int textPrefixIndex = truncatedFileContent.indexOf(TEXT_PREFIX, context.getCurrentIndex());
+            if (textPrefixIndex < 0) {
+                throw new GTSMeteorologicalMessageParseException(ErrorCode.NO_SEPARATION_OF_HEADING_AND_TEXT, context.getCurrentIndex(), content);
+            }
+            final String heading = content.substring(context.getCurrentIndex(), textPrefixIndex);
+            final int headingLineBreaksIndex = indexOfAnyLineBreak(heading);
+            if (headingLineBreaksIndex >= 0) {
+                throw new GTSMeteorologicalMessageParseException(ErrorCode.UNEXPECTED_LINE_BREAKS_IN_HEADING,
+                        context.getCurrentIndex() + headingLineBreaksIndex, content);
+            }
+            context.setCurrentIndex(textPrefixIndex + TEXT_PREFIX.length());
+            return heading;
+        }
+
+        private String parseText(final ParsingContext context, final int endIndex) {
+            final String content = context.getContent();
+            final String text;
+            try {
+                text = content.substring(context.getCurrentIndex(), endIndex);
+            } catch (final IndexOutOfBoundsException e) {
+                throw new GTSMeteorologicalMessageParseException(ErrorCode.UNEXPECTED_END_OF_TEXT, context.getCurrentIndex(), content, e);
+            }
+            context.setCurrentIndex(endIndex);
+            return text;
+        }
+
+        /**
+         * Parses provided string for bulletin heading and text content and populates this builder with parsed headingAndText.
+         * This parsing method is lenient. The first line of provided {@code headingAndText} is interpreted as the heading. Then any sequence of CR and LF
+         * characters is skipped, and the remaining part of the {@code headingAndText} string is interpreted as text content as is. If provided
+         * {@code headingAndText} contains no CR or LF characters, the whole string is interpreted as heading and text will be empty. If provided
+         * {@code headingAndText} is an empty string, both heading and text will be empty.
+         *
+         * <p>
+         * Note that this method does not affect any other property of this builder than {@code heading} and {@code text}.
+         * </p>
+         *
+         * @param headingAndText
+         *         heading and text string to parse
+         *
+         * @return this builder
+         */
+        public Builder parseHeadingAndTextLenient(final String headingAndText) {
+            requireNonNull(headingAndText, "headingAndText");
+            final String[] splitHeadingAndText = ANY_SEQUENCE_OF_LINE_BREAKS.split(headingAndText, 2);
+            return setHeading(splitHeadingAndText.length > 0 ? splitHeadingAndText[0] : "")//
+                    .setText(splitHeadingAndText.length > 1 ? splitHeadingAndText[1] : "");
+        }
+
+        public Builder clearTransmissionSequenceNumber() {
+            return setTransmissionSequenceNumber("");
+        }
+
+        public Optional<Integer> getTransmissionSequenceNumberAsInt() {
+            return transmissionSequenceNumberToInt(getTransmissionSequenceNumber());
+        }
+
+        public Builder setTransmissionSequenceNumberAsInt(final int number) {
+            return setTransmissionSequenceNumberAsInt(number, 3);
+        }
+
+        public Builder setTransmissionSequenceNumberAsInt(final int number, final int numberOfDigits) {
+            if (number < 0) {
+                throw new IllegalArgumentException("number is negative: " + number);
+            }
+            if (numberOfDigits < 1) {
+                throw new IllegalArgumentException("numberOfDigits is smaller than 1: " + numberOfDigits);
+            }
+            final String sequenceNumberString = String.format(Locale.ROOT, "%0" + numberOfDigits + "d", number);
+            if (sequenceNumberString.length() > numberOfDigits) {
+                throw new IllegalArgumentException("number greater than maximum of " + numberOfDigits + " digits: " + number);
+            }
+            return setTransmissionSequenceNumber(sequenceNumberString);
+        }
+
+    }
+}

--- a/src/main/java/fi/fmi/avi/util/GTSMeteorologicalMessageParseException.java
+++ b/src/main/java/fi/fmi/avi/util/GTSMeteorologicalMessageParseException.java
@@ -1,0 +1,44 @@
+package fi.fmi.avi.util;
+
+import java.util.Locale;
+
+public class GTSMeteorologicalMessageParseException extends GTSDataParseException {
+    private static final long serialVersionUID = 5204811503440506474L;
+
+    public GTSMeteorologicalMessageParseException(final ErrorCode errorCode, final int index, final String failedMessage) {
+        super(errorCode, index, failedMessage);
+    }
+
+    public GTSMeteorologicalMessageParseException(final ErrorCode errorCode, final int index, final String failedMessage, final Throwable cause) {
+        super(errorCode, index, failedMessage, cause);
+    }
+
+    @Override
+    public final ErrorCode getErrorCode() {
+        return (ErrorCode) super.getErrorCode();
+    }
+
+    public enum ErrorCode implements GTSDataParseException.ErrorCode {
+        MISSING_STARTING_LINE_PREFIX("Missing starting line prefix"), //
+        UNEXPECTED_STARTING_LINE_PREFIX("Unexpected starting line prefix"), //
+        UNEXPECTED_END_OF_TRANSMISSION_SEQUENCE_NUMBER("Unexpected end of data while parsing transmission sequence number"), //
+        UNEXPECTED_LINE_BREAKS_IN_TRANSMISSION_SEQUENCE_NUMBER("Unexpected line breaks in transmission sequence number"), //
+        MISSING_HEADING_PREFIX("Missing heading prefix"), //
+        UNEXPECTED_HEADING_PREFIX("Unexpected heading prefix"), //
+        MISSING_END_OF_MESSAGE_SIGNALS("Missing end of message signals"), //
+        NO_SEPARATION_OF_HEADING_AND_TEXT("Heading and text separator not found"), //
+        UNEXPECTED_LINE_BREAKS_IN_HEADING("Unexpected line breaks in heading"), //
+        UNEXPECTED_END_OF_TEXT("Unexpected end of data while parsing text");
+
+        private final String messageTemplate;
+
+        ErrorCode(final String message) {
+            this.messageTemplate = message + " starting at index %d";
+        }
+
+        @Override
+        public String message(final int index) {
+            return String.format(Locale.ROOT, messageTemplate, index);
+        }
+    }
+}

--- a/src/test/java/fi/fmi/avi/util/GTSDataExchangeTranscoderTest.java
+++ b/src/test/java/fi/fmi/avi/util/GTSDataExchangeTranscoderTest.java
@@ -1,0 +1,630 @@
+package fi.fmi.avi.util;
+
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import com.google.common.collect.Sets;
+
+import fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter;
+import fi.fmi.avi.util.GTSDataExchangeParseException.ErrorCode;
+import fi.fmi.avi.util.GTSDataExchangeTranscoder.ParseResult;
+import fi.fmi.avi.util.GTSDataExchangeTranscoder.Protocol;
+import fi.fmi.avi.util.GTSMeteorologicalMessage.MessageFormat;
+
+public class GTSDataExchangeTranscoderTest {
+    private static final String FTP_STANDARD_MESSAGE = "00000080" + "00" + "\u0001\r\r\n" //
+            + "013" + "\r\r\n"//
+            + "FTYU31 YUDO 160000" + "\r\r\n" //
+            + "TAF YUDO 160000Z NIL=\r\r\n" //
+            + "TAF YUDD 160000Z NIL=" + "\r\r\n\u0003";
+    private static final String FTP_SHORT_MESSAGE = "00000069" + "01" + "\r\r\n"//
+            + "FTYU31 YUDO 160000" + "\r\r\n" //
+            + "TAF YUDO 160000Z NIL=\r\r\n" //
+            + "TAF YUDD 160000Z NIL=";
+    private static final String SOCKET_ALPHANUMERIC_MESSAGE = "00000080" + "AN" + "\u0001\r\r\n" //
+            + "013" + "\r\r\n"//
+            + "FTYU31 YUDO 160000" + "\r\r\n" //
+            + "TAF YUDO 160000Z NIL=\r\r\n" //
+            + "TAF YUDD 160000Z NIL=" + "\r\r\n\u0003";
+    private static final String MESSAGE_HEADING = "FTYU31 YUDO 160000";
+    private static final String MESSAGE_TEXT = "TAF YUDO 160000Z NIL=\r\r\n" //
+            + "TAF YUDD 160000Z NIL=";
+    private static final String MESSAGE_SEQ_NUMBER_STRING = "013";
+    private static final GTSMeteorologicalMessage STANDARD_MESSAGE = GTSMeteorologicalMessage.builder()//
+            .setTransmissionSequenceNumber(MESSAGE_SEQ_NUMBER_STRING)//
+            .setHeading(MESSAGE_HEADING)//
+            .setText(MESSAGE_TEXT)//
+            .build();
+    private static final ParseResult FTP_STANDARD_PARSE_RESULT = ParseResult.builder()//
+            .setProtocol(Protocol.FTP)//
+            .setStartIndex(0)//
+            .setMessage(STANDARD_MESSAGE)//
+            .build();
+    private static final ParseResult SOCKET_ALPHANUMERIC_PARSE_RESULT = ParseResult.builder()//
+            .setProtocol(Protocol.SOCKET)//
+            .setStartIndex(0)//
+            .setMessage(STANDARD_MESSAGE)//
+            .build();
+    private static final GTSMeteorologicalMessage SHORT_MESSAGE = GTSMeteorologicalMessage.builder()//
+            .clearTransmissionSequenceNumber()//
+            .setHeading(MESSAGE_HEADING)//
+            .setText(MESSAGE_TEXT)//
+            .build();
+    private static final ParseResult FTP_SHORTPARSE_RESULT = ParseResult.builder()//
+            .setProtocol(Protocol.FTP)//
+            .setStartIndex(0)//
+            .setMessage(SHORT_MESSAGE)//
+            .build();
+    private static final Set<Protocol> ALL_PROTOCOLS = Collections.unmodifiableSet(EnumSet.allOf(Protocol.class));
+
+    static String stringOf(final MeteorologicalBulletinSpecialCharacter... specialCharacters) {
+        return Arrays.stream(specialCharacters)//
+                .map(MeteorologicalBulletinSpecialCharacter::getContent)//
+                .collect(Collectors.joining());
+    }
+
+    private static String checkMessageLength(final String gtsMessage) {
+        final int reportedMessageLength = Integer.parseInt(gtsMessage.substring(0, 8));
+        final int actualMessageLength = gtsMessage.length() - 10;
+        assertThat(actualMessageLength)//
+                .as("test integrity: message length")//
+                .isEqualTo(reportedMessageLength);
+        return gtsMessage;
+    }
+
+    private static void assertEqualProperties(final ParseResult actual, final ParseResult expected) {
+        assertThat(actual).as("actual").isNotNull();
+        assertThat(actual.getProtocol()).as("protocol").isEqualTo(expected.getProtocol());
+        assertThat(actual.getStartIndex()).as("startIndex").isEqualTo(expected.getStartIndex());
+        assertThat(actual.getMessage()).as("message").isPresent();
+        assertThat(expected.getMessage()).as("expected message").isPresent();
+        assertEqualProperties(actual.getMessage().get(), expected.getMessage().get());
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static void assertEqualProperties(final GTSMeteorologicalMessage actual, final GTSMeteorologicalMessage expected) {
+        assertThat(actual).as("actual").isNotNull();
+        assertThat(actual.getLength()).as("getLength").isEqualTo(expected.getLength());
+        assertThat(actual.getTransmissionSequenceNumber()).as("getTransmissionSequenceNumber").isEqualTo(expected.getTransmissionSequenceNumber());
+        assertThat(actual.getTransmissionSequenceNumberAsInt()).as("getTransmissionSequenceNumberAsInt")
+                .isEqualTo(expected.getTransmissionSequenceNumberAsInt());
+        assertThat(actual.getHeading()).as("getHeading").isEqualTo(expected.getHeading());
+        assertThat(actual.getText()).as("getText").isEqualTo(expected.getText());
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    private static void assertError(final ParseResult result, final Protocol expectedProtocol, final GTSDataParseException.ErrorCode expectedErrorCode,
+            final int expectedIndex, final String expectedFailedMessage) {
+        assertThat(result.getError()).as("error").isNotEmpty();
+        assertGTSDataParseException(expectedErrorCode, expectedIndex, expectedFailedMessage, result.getError().get());
+        assertThat(result.getMessage()).as("message").isEmpty();
+        assertThat(result.getProtocol().orElse(null)).as("protocol").isEqualTo(expectedProtocol);
+    }
+
+    private static void assertGTSDataParseException(final GTSDataParseException.ErrorCode expectedErrorCode, final int expectedIndex,
+            final String expectedFailedMessage, final GTSDataParseException exception) {
+        final Class<?> expectedExceptionType = expectedErrorCode.getClass().getDeclaringClass();
+        assertThat(exception).isInstanceOf(expectedExceptionType);
+        assertThat(exception.getMessage()).as("getMessage").isEqualTo(expectedErrorCode.message(expectedIndex));
+        assertThat(exception.getErrorCode()).as("getErrorCode").isEqualTo(expectedErrorCode);
+        assertThat(exception.getIndex()).as("getIndex").isEqualTo(expectedIndex);
+        assertThat(exception.getFailedMessage()).as("getFailedMessage").isEqualTo(expectedFailedMessage);
+    }
+
+    private static Stream<Set<Protocol>> protocolsContaining(final Protocol requiredProtocol) {
+        return Sets.powerSet(EnumSet.allOf(Protocol.class)).stream()//
+                .filter(set -> set.contains(requiredProtocol));
+    }
+
+    private static Stream<Set<Protocol>> allProtocols() {
+        return Sets.powerSet(EnumSet.allOf(Protocol.class)).stream()//
+                .filter(set -> !set.isEmpty());
+    }
+
+    @Test
+    public void parse_given_negative_offset_throws_exception() {
+        assertThatIllegalArgumentException()//
+                .isThrownBy(() -> GTSDataExchangeTranscoder.parse(FTP_STANDARD_MESSAGE, -1, ALL_PROTOCOLS))//
+                .withMessageContaining("Offset")//
+                .withMessageContaining("negative");
+    }
+
+    @Test
+    public void parse_given_empty_protocols_throws_exception() {
+        assertThatIllegalArgumentException()//
+                .isThrownBy(() -> GTSDataExchangeTranscoder.parse(FTP_STANDARD_MESSAGE, 0, Collections.emptySet()))//
+                .withMessageContaining("acceptedProtocols")//
+                .withMessageContaining("empty");
+    }
+
+    @Test
+    public void parse_parses_FTP_STANDARD_message() {
+        protocolsContaining(Protocol.FTP)//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(FTP_STANDARD_MESSAGE), 0, protocols);
+                    assertEqualProperties(result, FTP_STANDARD_PARSE_RESULT);
+                });
+    }
+
+    @Test
+    public void parse_parses_FTP_SHORT_message() {
+        protocolsContaining(Protocol.FTP)//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(FTP_SHORT_MESSAGE), 0, protocols);
+                    assertEqualProperties(result, FTP_SHORTPARSE_RESULT);
+                });
+    }
+
+    @Test
+    public void parse_parses_SOCKET_ALPHANUMERIC_message() {
+        protocolsContaining(Protocol.SOCKET)//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(SOCKET_ALPHANUMERIC_MESSAGE), 0, protocols);
+                    assertEqualProperties(result, SOCKET_ALPHANUMERIC_PARSE_RESULT);
+                });
+    }
+
+    @Test
+    public void parse_fails_when_message_ends_before_complete_message_length() {
+        final String inputMessage = "1234567";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(inputMessage, 0, protocols);
+                    assertError(result, null, ErrorCode.UNEXPECTED_END_OF_MESSAGE_LENGTH, 0, inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_when_message_length_is_not_a_number() {
+        final String messageLengthString = "1234567A";
+        final String inputMessage = new StringBuilder(FTP_STANDARD_MESSAGE)//
+                .replace(0, messageLengthString.length(), messageLengthString)//
+                .toString();
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(inputMessage, 0, protocols);
+                    assertError(result, null, ErrorCode.INVALID_MESSAGE_LENGTH, 0, inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_when_message_ends_before_complete_format_identifier() {
+        final String inputMessage = "123456780";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(inputMessage, 0, protocols);
+                    assertError(result, null, ErrorCode.UNEXPECTED_END_OF_FORMAT_IDENTIFIER, 8, inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_when_message_ends_before_complete_format_identifier2() {
+        final String inputMessage = "123456780" + GTSMeteorologicalMessage.END_OF_MESSAGE_SIGNALS;
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(inputMessage, 0, protocols);
+                    assertError(result, null, ErrorCode.INVALID_FORMAT_IDENTIFIER, 8, inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_when_format_identifier_is_not_a_number() {
+        final int formatIdentifierIndex = 8;
+        final String formatIdentifierString = "0A";
+        final String inputMessage = new StringBuilder(checkMessageLength(FTP_STANDARD_MESSAGE))//
+                .replace(formatIdentifierIndex, formatIdentifierIndex + formatIdentifierString.length(), formatIdentifierString)//
+                .toString();
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(inputMessage, 0, protocols);
+                    assertError(result, null, ErrorCode.INVALID_FORMAT_IDENTIFIER, 8, inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_when_format_identifier_is_not_a_supported_number() {
+        final int formatIdentifierIndex = 8;
+        final Stream<String> invalidFormatIdentifiers = IntStream.rangeClosed(2, 99)//
+                .mapToObj(formatIdentifier -> String.format(Locale.ROOT, "%02d", formatIdentifier));
+        assertThat(invalidFormatIdentifiers).allSatisfy(formatIdentifierString -> {
+            final String inputMessage = new StringBuilder(FTP_STANDARD_MESSAGE)//
+                    .replace(formatIdentifierIndex, formatIdentifierIndex + formatIdentifierString.length(), formatIdentifierString)//
+                    .toString();
+            allProtocols()//
+                    .forEach(protocols -> {
+                        final ParseResult result = GTSDataExchangeTranscoder.parse(inputMessage, 0, protocols);
+                        assertError(result, null, ErrorCode.INVALID_FORMAT_IDENTIFIER, 8, inputMessage);
+                    });
+        });
+    }
+
+    @Test
+    public void parse_fails_on_FTP_STANDARD_message_when_starting_line_prefix_is_not_found_at_expected_index() {
+        final String inputMessage = "00000003" + "00" + "\u0001\r\r";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(inputMessage), 0, protocols);
+                    assertError(result, Protocol.FTP, GTSMeteorologicalMessageParseException.ErrorCode.MISSING_STARTING_LINE_PREFIX, 10, inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_on_SOCKET_ALPHANUMERIC_message_when_starting_line_prefix_is_not_found_at_expected_index() {
+        final String inputMessage = "00000003" + "AN" + "\u0001\r\r";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(inputMessage), 0, protocols);
+                    assertError(result, Protocol.SOCKET, GTSMeteorologicalMessageParseException.ErrorCode.MISSING_STARTING_LINE_PREFIX, 10, inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_on_FTP_STANDARD_message_when_transmission_sequence_number_is_not_followed_by_heading_prefix() {
+        final String inputMessage = "00000027" + "00" + "\u0001\r\r\n" //
+                + "013" + "\r\r"//
+                + "FTYU31 YUDO 160000";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(inputMessage), 0, protocols);
+                    assertError(result, Protocol.FTP, GTSMeteorologicalMessageParseException.ErrorCode.UNEXPECTED_END_OF_TRANSMISSION_SEQUENCE_NUMBER, 14,
+                            inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_on_SOCKET_ALPHANUMERIC_message_when_transmission_sequence_number_is_not_followed_by_heading_prefix() {
+        final String inputMessage = "00000027" + "AN" + "\u0001\r\r\n" //
+                + "013" + "\r\r"//
+                + "FTYU31 YUDO 160000";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(inputMessage), 0, protocols);
+                    assertError(result, Protocol.SOCKET, GTSMeteorologicalMessageParseException.ErrorCode.UNEXPECTED_END_OF_TRANSMISSION_SEQUENCE_NUMBER, 14,
+                            inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_on_FTP_STANDARD_message_when_transmission_sequence_number_contains_line_break_chars() {
+        final String inputMessage = "00000079" + "00" + "\u0001\r\r\n" //
+                + "013" + "\r\r"//
+                + "FTYU31 YUDO 160000" + "\r\r\n" //
+                + "TAF YUDO 160000Z NIL=\r\r\n" //
+                + "TAF YUDD 160000Z NIL=" + "\r\r\n\u0003";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(inputMessage), 0, protocols);
+                    assertError(result, Protocol.FTP, GTSMeteorologicalMessageParseException.ErrorCode.UNEXPECTED_LINE_BREAKS_IN_TRANSMISSION_SEQUENCE_NUMBER,
+                            17, inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_on_SOCKET_ALPHANUMERIC_message_when_transmission_sequence_number_contains_line_break_chars() {
+        final String inputMessage = "00000079" + "AN" + "\u0001\r\r\n" //
+                + "013" + "\r\r"//
+                + "FTYU31 YUDO 160000" + "\r\r\n" //
+                + "TAF YUDO 160000Z NIL=\r\r\n" //
+                + "TAF YUDD 160000Z NIL=" + "\r\r\n\u0003";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(inputMessage), 0, protocols);
+                    assertError(result, Protocol.SOCKET,
+                            GTSMeteorologicalMessageParseException.ErrorCode.UNEXPECTED_LINE_BREAKS_IN_TRANSMISSION_SEQUENCE_NUMBER, 17, inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_on_FTP_STANDARD_message_when_message_does_not_end_with_expected_end_signals() {
+        final String inputMessage = "00000079" + "00" + "\u0001\r\r\n" //
+                + "013" + "\r\r\n"//
+                + "FTYU31 YUDO 160000" + "\r\r\n" //
+                + "TAF YUDO 160000Z NIL=\r\r\n" //
+                + "TAF YUDD 160000Z NIL=" + "\r\n\u0003";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(inputMessage), 0, protocols);
+                    assertError(result, Protocol.FTP, GTSMeteorologicalMessageParseException.ErrorCode.MISSING_END_OF_MESSAGE_SIGNALS, 85, inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_on_SOCKET_ALPHANUMERIC_message_when_message_does_not_end_with_expected_end_signals() {
+        final String inputMessage = "00000079" + "AN" + "\u0001\r\r\n" //
+                + "013" + "\r\r\n"//
+                + "FTYU31 YUDO 160000" + "\r\r\n" //
+                + "TAF YUDO 160000Z NIL=\r\r\n" //
+                + "TAF YUDD 160000Z NIL=" + "\r\n\u0003";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(inputMessage), 0, protocols);
+                    assertError(result, Protocol.SOCKET, GTSMeteorologicalMessageParseException.ErrorCode.MISSING_END_OF_MESSAGE_SIGNALS, 85, inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_on_FTP_STANDARD_message_when_heading_contains_line_break_characters() {
+        final Stream<String> inputMessages = Stream.of(//
+                        stringOf(CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED), //
+                        stringOf(CARRIAGE_RETURN, LINE_FEED), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, LINE_FEED))// Contains no CR+CR+LF sequence
+                .map(separator -> {
+                    final String message = "\u0001\r\r\n" //
+                            + "013" + "\r\r\n"//
+                            + "FTYU31 YUDO 160000" + separator //
+                            + "TAF YUDO 160000Z NIL=" + "\r\r\n" //
+                            + "TAF YUDD 160000Z NIL=" + "\r\r\n\u0003";
+                    return String.format(Locale.ROOT, "%08d00%s", message.length(), message);
+                });
+        assertThat(inputMessages)//
+                .allSatisfy(inputMessage -> allProtocols()//
+                        .forEach(protocols -> {
+                            final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(inputMessage), 0, protocols);
+                            assertError(result, Protocol.FTP, GTSMeteorologicalMessageParseException.ErrorCode.UNEXPECTED_LINE_BREAKS_IN_HEADING, 38,
+                                    inputMessage);
+                        }));
+    }
+
+    @Test
+    public void parse_fails_on_SOCKET_ALPHANUMERIC_message_when_heading_contains_line_break_characters() {
+        final Stream<String> inputMessages = Stream.of(//
+                        stringOf(CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED), //
+                        stringOf(CARRIAGE_RETURN, LINE_FEED), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, LINE_FEED))// Contains no CR+CR+LF sequence
+                .map(separator -> {
+                    final String message = "\u0001\r\r\n" //
+                            + "013" + "\r\r\n"//
+                            + "FTYU31 YUDO 160000" + separator //
+                            + "TAF YUDO 160000Z NIL=" + "\r\r\n" //
+                            + "TAF YUDD 160000Z NIL=" + "\r\r\n\u0003";
+                    return String.format(Locale.ROOT, "%08d00%s", message.length(), message);
+                });
+        assertThat(inputMessages)//
+                .allSatisfy(inputMessage -> allProtocols()//
+                        .forEach(protocols -> {
+                            final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(inputMessage), 0, protocols);
+                            assertError(result, Protocol.FTP, GTSMeteorologicalMessageParseException.ErrorCode.UNEXPECTED_LINE_BREAKS_IN_HEADING, 38,
+                                    inputMessage);
+                        }));
+    }
+
+    @Test
+    public void parse_fails_on_FTP_SHORT_message_when_heading_contains_line_break_characters() {
+        final Stream<String> inputMessages = Stream.of(//
+                        stringOf(CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED), //
+                        stringOf(CARRIAGE_RETURN, LINE_FEED), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, LINE_FEED))// Contains no CR+CR+LF sequence
+                .map(separator -> {
+                    final String message = "\r\r\n"//
+                            + "FTYU31 YUDO 160000" + separator //
+                            + "TAF YUDO 160000Z NIL=" + "\r\r\n" //
+                            + "TAF YUDD 160000Z NIL=";
+                    return String.format(Locale.ROOT, "%08d01%s", message.length(), message);
+                });
+        assertThat(inputMessages)//
+                .allSatisfy(inputMessage -> allProtocols()//
+                        .forEach(protocols -> {
+                            final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(inputMessage), 0, protocols);
+                            assertError(result, Protocol.FTP, GTSMeteorologicalMessageParseException.ErrorCode.UNEXPECTED_LINE_BREAKS_IN_HEADING, 31,
+                                    inputMessage);
+                        }));
+    }
+
+    @Test
+    public void parse_fails_on_FTP_SHORT_message_when_heading_is_not_preceded_by_expected_prefix() {
+        final String inputMessage = "00000068" + "01" + "\r\r" //
+                + "FTYU31 YUDO 160000" + "\r\r\n" //
+                + "TAF YUDO 160000Z NIL=\r\r\n" //
+                + "TAF YUDD 160000Z NIL=";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(inputMessage), 0, protocols);
+                    assertError(result, Protocol.FTP, GTSMeteorologicalMessageParseException.ErrorCode.MISSING_HEADING_PREFIX, 10, inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_on_FTP_SHORT_message_when_heading_and_text_separator_not_found() {
+        final String inputMessage = "00000043" + "01" + "\r\r\n"//
+                + "FTYU31 YUDO 160000 " //
+                + "TAF YUDD 160000Z NIL=";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(checkMessageLength(inputMessage), 0, protocols);
+                    assertError(result, Protocol.FTP, GTSMeteorologicalMessageParseException.ErrorCode.NO_SEPARATION_OF_HEADING_AND_TEXT, 13, inputMessage);
+                });
+    }
+
+    @Test
+    public void parse_fails_on_FTP_SHORT_message_when_actual_content_is_smaller_than_reported_message_length() {
+        final String inputMessage = "00000100" + "01" + "\r\r\n"//
+                + "FTYU31 YUDO 160000" + "\r\r\n" //
+                + "TAF YUDO 160000Z NIL=" + "\r\r\n" //
+                + "TAF YUDD 160000Z NIL=";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final ParseResult result = GTSDataExchangeTranscoder.parse(inputMessage, 0, protocols);
+                    assertError(result, Protocol.FTP, GTSMeteorologicalMessageParseException.ErrorCode.UNEXPECTED_END_OF_TEXT, 34, inputMessage);
+                });
+    }
+
+    @Test
+    public void parseAll_returns_empty_list_given_empty_string() {
+        allProtocols().forEach(protocols -> {
+            final List<ParseResult> messages = GTSDataExchangeTranscoder.parseAll("", protocols);
+            assertThat(messages).isEmpty();
+        });
+    }
+
+    @Test
+    public void parseAll_parses_multiple_messages_in_supported_protocols_and_formats() {
+        final StringBuilder inputMessageBuilder = new StringBuilder();
+        inputMessageBuilder.append(FTP_STANDARD_MESSAGE);
+        final int message2Index = inputMessageBuilder.length();
+        inputMessageBuilder.append(FTP_SHORT_MESSAGE);
+        final int message3Index = inputMessageBuilder.length();
+        inputMessageBuilder.append(SOCKET_ALPHANUMERIC_MESSAGE);
+        final String inputMessage = inputMessageBuilder.toString();
+        final Iterator<ParseResult> messages = GTSDataExchangeTranscoder.parseAll(inputMessage).iterator();
+        assertEqualProperties(messages.next(), FTP_STANDARD_PARSE_RESULT);
+        assertEqualProperties(messages.next(), FTP_SHORTPARSE_RESULT.toBuilder().setStartIndex(message2Index).build());
+        assertEqualProperties(messages.next(), SOCKET_ALPHANUMERIC_PARSE_RESULT.toBuilder().setStartIndex(message3Index).build());
+        assertThat(messages.hasNext()).as("Expect no more messages").isFalse();
+    }
+
+    @Test
+    public void parseAll_ignores_trailing_whitespace() {
+        protocolsContaining(Protocol.FTP)//
+                .forEach(protocols -> {
+                    final Iterator<ParseResult> messages = GTSDataExchangeTranscoder.parseAll(FTP_STANDARD_MESSAGE + " \r\n", protocols).iterator();
+                    assertEqualProperties(messages.next(), FTP_STANDARD_PARSE_RESULT);
+                    assertThat(messages.hasNext()).as("Expect no more messages").isFalse();
+                });
+    }
+
+    @Test
+    public void parseAll_returns_single_error() {
+        final String inputMessage = "000";
+        allProtocols()//
+                .forEach(protocols -> {
+                    final Iterator<ParseResult> messages = GTSDataExchangeTranscoder.parseAll(inputMessage, protocols).iterator();
+                    assertError(messages.next(), null, ErrorCode.UNEXPECTED_END_OF_MESSAGE_LENGTH, 0, inputMessage);
+                    assertThat(messages.hasNext()).as("Expect no more messages").isFalse();
+                });
+    }
+
+    @Test
+    public void parseAll_returns_whitespaces_between_messages_as_errors() {
+        final StringBuilder inputMessageBuilder = new StringBuilder();
+        inputMessageBuilder.append(FTP_STANDARD_MESSAGE);
+        final int error1Index = inputMessageBuilder.length();
+        inputMessageBuilder.append("\n");
+        final int message2Index = inputMessageBuilder.length();
+        inputMessageBuilder.append(FTP_SHORT_MESSAGE);
+        final int error2Index = inputMessageBuilder.length();
+        inputMessageBuilder.append(" ");
+        final int message3Index = inputMessageBuilder.length();
+        inputMessageBuilder.append(SOCKET_ALPHANUMERIC_MESSAGE);
+        final String inputMessage = inputMessageBuilder.toString();
+
+        final Iterator<ParseResult> messages = GTSDataExchangeTranscoder.parseAll(inputMessage).iterator();
+        assertEqualProperties(messages.next(), FTP_STANDARD_PARSE_RESULT);
+        assertError(messages.next(), null, ErrorCode.INVALID_MESSAGE_LENGTH, error1Index, inputMessage);
+        assertEqualProperties(messages.next(), FTP_SHORTPARSE_RESULT.toBuilder().setStartIndex(message2Index).build());
+        assertError(messages.next(), null, ErrorCode.INVALID_MESSAGE_LENGTH, error2Index, inputMessage);
+        assertEqualProperties(messages.next(), SOCKET_ALPHANUMERIC_PARSE_RESULT.toBuilder().setStartIndex(message3Index).build());
+        assertThat(messages.hasNext()).as("Expect no more messages").isFalse();
+    }
+
+    @Test
+    public void parseAll_continues_after_error() {
+        final String inputMessage1 = "00000100" + "00" + "\u0001\r\r\n" //
+                + "013" + "\r\r\n"//
+                + "FTYU31 YUDO 160000" + "\r\r\n" //
+                + "TAF YUDO 160000Z NIL=\r\r\n" //
+                + "TAF YUDD 160000Z NIL=" + "\r\r\n\u0003";
+        final String inputMessage = inputMessage1 + FTP_STANDARD_MESSAGE;
+        final int message2Index = inputMessage1.length();
+        protocolsContaining(Protocol.FTP)//
+                .forEach(protocols -> {
+                    final Iterator<ParseResult> messages = GTSDataExchangeTranscoder.parseAll(inputMessage, protocols).iterator();
+                    assertError(messages.next(), Protocol.FTP, GTSMeteorologicalMessageParseException.ErrorCode.MISSING_END_OF_MESSAGE_SIGNALS, 106,
+                            inputMessage);
+                    assertEqualProperties(messages.next(), FTP_STANDARD_PARSE_RESULT.toBuilder().setStartIndex(message2Index).build());
+                    assertThat(messages.hasNext()).as("Expect no more messages").isFalse();
+                });
+    }
+
+    @Test
+    public void toString_given_standard_message_returns_string_equal_to_original_FTP_STANDARD_message() {
+        assertThat(GTSDataExchangeTranscoder.toString(STANDARD_MESSAGE, Protocol.FTP)).isEqualTo(FTP_STANDARD_MESSAGE);
+    }
+
+    @Test
+    public void toString_given_short_message_returns_string_equal_to_original_FTP_SHORT_message() {
+        assertThat(GTSDataExchangeTranscoder.toString(SHORT_MESSAGE, Protocol.FTP)).isEqualTo(FTP_SHORT_MESSAGE);
+    }
+
+    @Test
+    public void toString_given_standard_message_returns_string_equal_to_original_SOCKET_ALPHANUMERIC_message() {
+        assertThat(GTSDataExchangeTranscoder.toString(STANDARD_MESSAGE, Protocol.SOCKET)).isEqualTo(SOCKET_ALPHANUMERIC_MESSAGE);
+    }
+
+    @Test
+    public void toString_given_FTP_STANDARD_outputs_expected_message() {
+        assertThat(GTSDataExchangeTranscoder.toString(STANDARD_MESSAGE, Protocol.FTP, MessageFormat.STANDARD)).isEqualTo(FTP_STANDARD_MESSAGE);
+    }
+
+    @Test
+    public void toString_given_FTP_SHORT_outputs_expected_message() {
+        assertThat(GTSDataExchangeTranscoder.toString(STANDARD_MESSAGE, Protocol.FTP, MessageFormat.SHORT)).isEqualTo(FTP_SHORT_MESSAGE);
+    }
+
+    @Test
+    public void toString_given_SOCKET_STANDARD_outputs_expected_message() {
+        assertThat(GTSDataExchangeTranscoder.toString(STANDARD_MESSAGE, Protocol.SOCKET, MessageFormat.STANDARD)).isEqualTo(SOCKET_ALPHANUMERIC_MESSAGE);
+    }
+
+    @Test
+    public void toString_given_HEADING_AND_TEXT_fails() {
+        Arrays.stream(Protocol.values())//
+                .forEach(protocol -> assertThatIllegalArgumentException()//
+                        .isThrownBy(() -> GTSDataExchangeTranscoder.toString(STANDARD_MESSAGE, protocol, MessageFormat.HEADING_AND_TEXT)));
+    }
+
+    @Test
+    public void toString_given_SOCKET_supports_only_STANDARD_message_format() {
+        Arrays.stream(MessageFormat.values())//
+                .filter(format -> format != MessageFormat.STANDARD)//
+                .forEach(format -> assertThatIllegalArgumentException()//
+                        .isThrownBy(() -> GTSDataExchangeTranscoder.toString(STANDARD_MESSAGE, Protocol.SOCKET, format)));
+    }
+
+    @Test
+    public void parseResult_build_fails_when_both_message_and_error_are_empty() {
+        final ParseResult.Builder builder = ParseResult.builder()//
+                .setStartIndex(0)//
+                .clearMessage()//
+                .clearError();
+        assertThatIllegalStateException()//
+                .isThrownBy(() -> builder.build())//
+                .withMessageContaining("Message")//
+                .withMessageContaining("error")//
+                .withMessageContaining("empty");
+    }
+
+    @Test
+    public void parseResult_build_fails_when_both_message_and_error_are_present() {
+        final ParseResult.Builder builder = ParseResult.builder()//
+                .setStartIndex(0)//
+                .setMessage(STANDARD_MESSAGE)//
+                .setError(new GTSDataExchangeParseException(ErrorCode.INVALID_MESSAGE_LENGTH, 0, ""));
+        assertThatIllegalStateException()//
+                .isThrownBy(() -> builder.build())//
+                .withMessageContaining("Message")//
+                .withMessageContaining("error")//
+                .withMessageContaining("present");
+    }
+}

--- a/src/test/java/fi/fmi/avi/util/GTSExchangeFileTemplateTest.java
+++ b/src/test/java/fi/fmi/avi/util/GTSExchangeFileTemplateTest.java
@@ -17,6 +17,12 @@ import org.junit.Test;
 
 import fi.fmi.avi.util.GTSExchangeFileParseException.ParseErrorCode;
 
+/**
+ * Deprecated.
+ *
+ * @deprecated along with {@link GTSExchangeFileTemplate}
+ */
+@Deprecated
 public class GTSExchangeFileTemplateTest {
     private static final String MESSAGE_LONG = "00000080" + "00" + "\u0001\r\r\n" //
             + "013" + "\r\r\n"//
@@ -108,11 +114,11 @@ public class GTSExchangeFileTemplateTest {
     @Test
     public void parseHeadingAndText_fails_when_heading_contains_line_break_characters() {
         final Stream<String> inputMessages = Stream.of(//
-                stringOf(CARRIAGE_RETURN), //
-                stringOf(LINE_FEED), //
-                stringOf(CARRIAGE_RETURN, LINE_FEED), //
-                stringOf(LINE_FEED, CARRIAGE_RETURN), //
-                stringOf(LINE_FEED, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, LINE_FEED))// Contains no CR+CR+LF sequence
+                        stringOf(CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED), //
+                        stringOf(CARRIAGE_RETURN, LINE_FEED), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, LINE_FEED))// Contains no CR+CR+LF sequence
                 .map(separator -> MESSAGE_HEADING + separator + MESSAGE_TEXT);
         assertThat(inputMessages)//
                 .allSatisfy(inputMessage -> assertThatExceptionOfType(GTSExchangeFileParseException.class)//
@@ -138,12 +144,12 @@ public class GTSExchangeFileTemplateTest {
     @Test
     public void parseHeadingAndTextLenient_interprets_any_combination_of_CR_and_LF_chars_as_heading_and_text_separator() {
         final Stream<String> inputMessages = Stream.of(//
-                GTSExchangeFileTemplate.TEXT_PREFIX, //
-                stringOf(CARRIAGE_RETURN), //
-                stringOf(LINE_FEED), //
-                stringOf(CARRIAGE_RETURN, LINE_FEED), //
-                stringOf(LINE_FEED, CARRIAGE_RETURN), //
-                stringOf(LINE_FEED, CARRIAGE_RETURN, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, CARRIAGE_RETURN, CARRIAGE_RETURN, LINE_FEED))//
+                        GTSExchangeFileTemplate.TEXT_PREFIX, //
+                        stringOf(CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED), //
+                        stringOf(CARRIAGE_RETURN, LINE_FEED), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, CARRIAGE_RETURN, CARRIAGE_RETURN, LINE_FEED))//
                 .map(separator -> MESSAGE_HEADING + separator + MESSAGE_TEXT);
         assertThat(inputMessages).allSatisfy(message -> {
             final GTSExchangeFileTemplate.Builder builder = builder().parseHeadingAndTextLenient(message);
@@ -274,11 +280,11 @@ public class GTSExchangeFileTemplateTest {
     @Test
     public void parse_fails_on_format_00_message_when_heading_contains_line_break_characters() {
         final Stream<String> inputMessages = Stream.of(//
-                stringOf(CARRIAGE_RETURN), //
-                stringOf(LINE_FEED), //
-                stringOf(CARRIAGE_RETURN, LINE_FEED), //
-                stringOf(LINE_FEED, CARRIAGE_RETURN), //
-                stringOf(LINE_FEED, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, LINE_FEED))// Contains no CR+CR+LF sequence
+                        stringOf(CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED), //
+                        stringOf(CARRIAGE_RETURN, LINE_FEED), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, LINE_FEED))// Contains no CR+CR+LF sequence
                 .map(separator -> {
                     final String message = "\u0001\r\r\n" //
                             + "013" + "\r\r\n"//
@@ -296,11 +302,11 @@ public class GTSExchangeFileTemplateTest {
     @Test
     public void parse_fails_on_format_01_message_when_heading_contains_line_break_characters() {
         final Stream<String> inputMessages = Stream.of(//
-                stringOf(CARRIAGE_RETURN), //
-                stringOf(LINE_FEED), //
-                stringOf(CARRIAGE_RETURN, LINE_FEED), //
-                stringOf(LINE_FEED, CARRIAGE_RETURN), //
-                stringOf(LINE_FEED, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, LINE_FEED))// Contains no CR+CR+LF sequence
+                        stringOf(CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED), //
+                        stringOf(CARRIAGE_RETURN, LINE_FEED), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, LINE_FEED))// Contains no CR+CR+LF sequence
                 .map(separator -> {
                     final String message = "\r\r\n"//
                             + "FTYU31 YUDO 160000" + separator //

--- a/src/test/java/fi/fmi/avi/util/GTSMeteorologicalMessageTest.java
+++ b/src/test/java/fi/fmi/avi/util/GTSMeteorologicalMessageTest.java
@@ -1,0 +1,515 @@
+package fi.fmi.avi.util;
+
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.CARRIAGE_RETURN;
+import static fi.fmi.avi.model.bulletin.MeteorologicalBulletinSpecialCharacter.LINE_FEED;
+import static fi.fmi.avi.util.GTSMeteorologicalMessage.stringOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
+import com.google.common.collect.Sets;
+
+import fi.fmi.avi.util.GTSMeteorologicalMessage.MessageFormat;
+import fi.fmi.avi.util.GTSMeteorologicalMessageParseException.ErrorCode;
+
+public class GTSMeteorologicalMessageTest {
+    private static final String INITIAL_SEQ_NUMBER_STRING = "097";
+    private static final int INITIAL_SEQ_NUMBER = 97;
+    private static final String MESSAGE_STANDARD_STRING = "\u0001\r\r\n" //
+            + "013" + "\r\r\n"//
+            + "FTYU31 YUDO 160000" + "\r\r\n" //
+            + "TAF YUDO 160000Z NIL=\r\r\n" //
+            + "TAF YUDD 160000Z NIL=" + "\r\r\n\u0003";
+    private static final String MESSAGE_SHORT_STRING = "\r\r\n"//
+            + "FTYU31 YUDO 160000" + "\r\r\n" //
+            + "TAF YUDO 160000Z NIL=\r\r\n" //
+            + "TAF YUDD 160000Z NIL=";
+    private static final String MESSAGE_HEADING_AND_TEXT = "FTYU31 YUDO 160000" + "\r\r\n" //
+            + "TAF YUDO 160000Z NIL=\r\r\n" //
+            + "TAF YUDD 160000Z NIL=";
+    private static final String MESSAGE_HEADING = "FTYU31 YUDO 160000";
+    private static final String MESSAGE_TEXT = "TAF YUDO 160000Z NIL=\r\r\n" //
+            + "TAF YUDD 160000Z NIL=";
+    private static final String MESSAGE_SEQ_NUMBER_STRING = "013";
+    private static final int MESSAGE_STANDARD_LENGTH = 80;
+    private static final int MESSAGE_SHORT_LENGTH = 69;
+    private static final GTSMeteorologicalMessage MESSAGE_STANDARD = GTSMeteorologicalMessage.builder()//
+            .setTransmissionSequenceNumber(MESSAGE_SEQ_NUMBER_STRING)//
+            .setHeading(MESSAGE_HEADING)//
+            .setText(MESSAGE_TEXT)//
+            .build();
+    private static final GTSMeteorologicalMessage MESSAGE_SHORT = GTSMeteorologicalMessage.builder()//
+            .clearTransmissionSequenceNumber()//
+            .setHeading(MESSAGE_HEADING)//
+            .setText(MESSAGE_TEXT)//
+            .build();
+
+    private static GTSMeteorologicalMessage.Builder builder() {
+        return GTSMeteorologicalMessage.builder()//
+                .setTransmissionSequenceNumber(INITIAL_SEQ_NUMBER_STRING)//
+                .setHeading("INIT99 IALH 012345")//
+                .setText("INITIAL TEXT");
+    }
+
+    private static void assertEqualProperties(final GTSMeteorologicalMessage actual, final GTSMeteorologicalMessage expected) {
+        assertThat(actual).as("actual").isNotNull();
+        assertThat(actual.getLength()).as("getLength").isEqualTo(expected.getLength());
+        assertThat(actual.getTransmissionSequenceNumber()).as("getTransmissionSequenceNumber").isEqualTo(expected.getTransmissionSequenceNumber());
+        assertThat(actual.getTransmissionSequenceNumberAsInt()).as("getTransmissionSequenceNumberAsInt")
+                .isEqualTo(expected.getTransmissionSequenceNumberAsInt());
+        assertThat(actual.getHeading()).as("getHeading").isEqualTo(expected.getHeading());
+        assertThat(actual.getText()).as("getText").isEqualTo(expected.getText());
+    }
+
+    private static void assertEqualProperties(final GTSMeteorologicalMessage.Builder actual, final GTSMeteorologicalMessage expected) {
+        assertThat(actual).as("actual").isNotNull();
+        if (expected.getTransmissionSequenceNumber().isEmpty()) {
+            assertInitialTransmissionSequenceNumber(actual);
+        }
+        assertThat(actual.getTransmissionSequenceNumber()).as("getTransmissionSequenceNumber").isEqualTo(expected.getTransmissionSequenceNumber());
+        assertThat(actual.getTransmissionSequenceNumberAsInt()).as("getTransmissionSequenceNumberAsInt")
+                .isEqualTo(expected.getTransmissionSequenceNumberAsInt());
+        assertThat(actual.getHeading()).as("getHeading").isEqualTo(expected.getHeading());
+        assertThat(actual.getText()).as("getText").isEqualTo(expected.getText());
+    }
+
+    private static void assertInitialTransmissionSequenceNumber(final GTSMeteorologicalMessage.Builder message) {
+        assertThat(message.getTransmissionSequenceNumber()).as("getTransmissionSequenceNumber").isEqualTo(INITIAL_SEQ_NUMBER_STRING);
+        assertThat(message.getTransmissionSequenceNumberAsInt()).as("getTransmissionSequenceNumberAsInt").hasValue(INITIAL_SEQ_NUMBER);
+        message.clearTransmissionSequenceNumber();
+    }
+
+    private static void assertGTSExchangeFileParseException(final ErrorCode expectedErrorCode, final int expectedIndex, final String expectedFailedMessage,
+            final GTSMeteorologicalMessageParseException exception) {
+        assertThat(exception.getMessage()).as("getMessage").isEqualTo(expectedErrorCode.message(expectedIndex));
+        assertThat(exception.getErrorCode()).as("getErrorCode").isEqualTo(expectedErrorCode);
+        assertThat(exception.getIndex()).as("getIndex").isEqualTo(expectedIndex);
+        assertThat(exception.getFailedMessage()).as("getFailedMessage").isEqualTo(expectedFailedMessage);
+    }
+
+    private static Stream<Set<MessageFormat>> messageFormatsContaining(final MessageFormat requiredFormat) {
+        return Sets.powerSet(EnumSet.allOf(MessageFormat.class)).stream()//
+                .filter(set -> set.contains(requiredFormat));
+    }
+
+    private static Stream<Set<MessageFormat>> messageFormatsWithout(final MessageFormat omittedFormat) {
+        return Sets.powerSet(EnumSet.allOf(MessageFormat.class)).stream()//
+                .filter(set -> !set.isEmpty() && !set.contains(omittedFormat));
+    }
+
+    @Test
+    public void parseHeadingAndTextLenient_results_equal_to_short_message() {
+        final GTSMeteorologicalMessage.Builder builder = builder().parseHeadingAndTextLenient(MESSAGE_HEADING_AND_TEXT);
+        assertEqualProperties(builder, MESSAGE_SHORT);
+        assertEqualProperties(builder.build(), MESSAGE_SHORT);
+    }
+
+    @Test
+    public void parseHeadingAndTextLenient_parses_empty_string_to_empty_heading_and_text() {
+        final GTSMeteorologicalMessage.Builder builder = builder().parseHeadingAndTextLenient("");
+        assertThat(builder.getHeading()).as("getHeading").isEmpty();
+        assertThat(builder.getText()).as("getText").isEmpty();
+    }
+
+    @Test
+    public void parseHeadingAndTextLenient_interprets_any_combination_of_CR_and_LF_chars_as_heading_and_text_separator() {
+        final Stream<String> inputMessages = Stream.of(//
+                        GTSMeteorologicalMessage.TEXT_PREFIX, //
+                        stringOf(CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED), //
+                        stringOf(CARRIAGE_RETURN, LINE_FEED), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN), //
+                        stringOf(LINE_FEED, CARRIAGE_RETURN, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, CARRIAGE_RETURN, CARRIAGE_RETURN, LINE_FEED))//
+                .map(separator -> MESSAGE_HEADING + separator + MESSAGE_TEXT);
+        assertThat(inputMessages).allSatisfy(message -> {
+            final GTSMeteorologicalMessage.Builder builder = builder().parseHeadingAndTextLenient(message);
+            assertThat(builder.getHeading()).as("getHeading").isEqualTo(MESSAGE_HEADING);
+            assertThat(builder.getText()).as("getText").isEqualTo(MESSAGE_TEXT);
+        });
+    }
+
+    @Test
+    public void parse_parses_standard_message() {
+        final GTSMeteorologicalMessage.Builder builder = builder().parse(MESSAGE_STANDARD_STRING);
+        assertEqualProperties(builder, MESSAGE_STANDARD);
+        assertEqualProperties(builder.build(), MESSAGE_STANDARD);
+    }
+
+    @Test
+    public void parse_STANDARD_parses_standard_message() {
+        messageFormatsContaining(MessageFormat.STANDARD)//
+                .forEach(acceptedFormats -> {
+                    final GTSMeteorologicalMessage.Builder builder = builder().parse(MESSAGE_STANDARD_STRING, acceptedFormats);
+                    assertEqualProperties(builder, MESSAGE_STANDARD);
+                    assertEqualProperties(builder.build(), MESSAGE_STANDARD);
+                });
+    }
+
+    @Test
+    public void parse_not_STANDARD_fails_on_standard_message() {
+        messageFormatsWithout(MessageFormat.STANDARD)//
+                .forEach(acceptedFormats -> {
+                    assertThatExceptionOfType(GTSMeteorologicalMessageParseException.class)//
+                            .isThrownBy(() -> builder().parse(MESSAGE_STANDARD_STRING, acceptedFormats))//
+                            .satisfies(e -> assertGTSExchangeFileParseException(ErrorCode.UNEXPECTED_STARTING_LINE_PREFIX, 0, MESSAGE_STANDARD_STRING, e));
+                });
+    }
+
+    @Test
+    public void parse_parses_short_message() {
+        final GTSMeteorologicalMessage.Builder builder = builder().parse(MESSAGE_SHORT_STRING);
+        assertEqualProperties(builder, MESSAGE_SHORT);
+        assertEqualProperties(builder.build(), MESSAGE_SHORT);
+    }
+
+    @Test
+    public void parse_SHORT_parses_short_message() {
+        messageFormatsContaining(MessageFormat.SHORT)//
+                .forEach(acceptedFormats -> {
+                    final GTSMeteorologicalMessage.Builder builder = builder().parse(MESSAGE_SHORT_STRING, acceptedFormats);
+                    assertEqualProperties(builder, MESSAGE_SHORT);
+                    assertEqualProperties(builder.build(), MESSAGE_SHORT);
+                });
+    }
+
+    @Test
+    public void parse_not_SHORT_fails_on_short_message() {
+        messageFormatsWithout(MessageFormat.SHORT)//
+                .forEach(acceptedFormats -> {
+                    final ErrorCode expectedErrorCode = acceptedFormats.contains(MessageFormat.HEADING_AND_TEXT)
+                            ? ErrorCode.UNEXPECTED_HEADING_PREFIX
+                            : ErrorCode.MISSING_STARTING_LINE_PREFIX;
+                    assertThatExceptionOfType(GTSMeteorologicalMessageParseException.class)//
+                            .isThrownBy(() -> builder().parse(MESSAGE_SHORT_STRING, acceptedFormats))//
+                            .satisfies(e -> assertGTSExchangeFileParseException(expectedErrorCode, 0, MESSAGE_SHORT_STRING, e));
+                });
+    }
+
+    @Test
+    public void parse_parses_heading_and_text() {
+        final GTSMeteorologicalMessage.Builder builder = builder().parse(MESSAGE_HEADING_AND_TEXT);
+        assertEqualProperties(builder, MESSAGE_SHORT);
+        assertEqualProperties(builder.build(), MESSAGE_SHORT);
+    }
+
+    @Test
+    public void parse_HEADING_AND_TEXT_parses_heading_and_text() {
+        messageFormatsContaining(MessageFormat.HEADING_AND_TEXT)//
+                .forEach(acceptedFormats -> {
+                    final GTSMeteorologicalMessage.Builder builder = builder().parse(MESSAGE_HEADING_AND_TEXT, acceptedFormats);
+                    assertEqualProperties(builder, MESSAGE_SHORT);
+                    assertEqualProperties(builder.build(), MESSAGE_SHORT);
+                });
+    }
+
+    @Test
+    public void parse_not_HEADING_AND_TEXT_fails_on_heading_and_text() {
+        messageFormatsWithout(MessageFormat.HEADING_AND_TEXT)//
+                .forEach(acceptedFormats -> {
+                    final ErrorCode expectedErrorCode = acceptedFormats.contains(MessageFormat.STANDARD)
+                            ? ErrorCode.MISSING_STARTING_LINE_PREFIX
+                            : ErrorCode.MISSING_HEADING_PREFIX;
+                    assertThatExceptionOfType(GTSMeteorologicalMessageParseException.class)//
+                            .isThrownBy(() -> builder().parse(MESSAGE_HEADING_AND_TEXT, acceptedFormats))//
+                            .satisfies(e -> assertGTSExchangeFileParseException(expectedErrorCode, 0, MESSAGE_HEADING_AND_TEXT, e));
+                });
+    }
+
+    @Test
+    public void parse_fails_when_heading_and_text_separator_not_found() {
+        messageFormatsContaining(MessageFormat.HEADING_AND_TEXT)//
+                .forEach(acceptedFormats -> {
+                    final String inputMessage = MESSAGE_HEADING + "\r\nTAF YUDO 160000Z NIL=";
+                    assertThatExceptionOfType(GTSMeteorologicalMessageParseException.class)//
+                            .isThrownBy(() -> builder().parse(inputMessage, acceptedFormats))//
+                            .satisfies(e -> assertGTSExchangeFileParseException(ErrorCode.NO_SEPARATION_OF_HEADING_AND_TEXT, 0, inputMessage, e));
+                });
+    }
+
+    @Test
+    public void parse_fails_when_standard_message_heading_and_text_heading_contains_line_break_characters() {
+        messageFormatsContaining(MessageFormat.HEADING_AND_TEXT)//
+                .forEach(acceptedFormats -> {
+                    final Stream<String> inputMessages = Stream.of(//
+                                    stringOf(CARRIAGE_RETURN), //
+                                    stringOf(LINE_FEED), //
+                                    stringOf(CARRIAGE_RETURN, LINE_FEED), //
+                                    stringOf(LINE_FEED, CARRIAGE_RETURN), //
+                                    stringOf(LINE_FEED, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, LINE_FEED))// Contains no CR+CR+LF sequence
+                            .map(separator -> MESSAGE_HEADING + separator + MESSAGE_TEXT);
+                    assertThat(inputMessages)//
+                            .allSatisfy(inputMessage -> assertThatExceptionOfType(GTSMeteorologicalMessageParseException.class)//
+                                    .isThrownBy(() -> builder().parse(inputMessage, acceptedFormats))//
+                                    .satisfies(e -> assertGTSExchangeFileParseException(ErrorCode.UNEXPECTED_LINE_BREAKS_IN_HEADING, MESSAGE_HEADING.length(),
+                                            inputMessage, e)));
+                });
+    }
+
+    @Test
+    public void parse_fails_when_standard_message_transmission_sequence_number_contains_line_break_chars() {
+        messageFormatsContaining(MessageFormat.STANDARD)//
+                .forEach(acceptedFormats -> {
+                    final String inputMessage = "\u0001\r\r\n" //
+                            + "013\r" + "\r\r\n"//
+                            + "FTYU31 YUDO 160000" + "\r\r\n" //
+                            + "TAF YUDO 160000Z NIL=\r\r\n" //
+                            + "TAF YUDD 160000Z NIL=" + "\r\r\n\u0003";
+                    assertThatExceptionOfType(GTSMeteorologicalMessageParseException.class)//
+                            .isThrownBy(() -> builder().parse(inputMessage, acceptedFormats))//
+                            .satisfies(
+                                    e -> assertGTSExchangeFileParseException(ErrorCode.UNEXPECTED_LINE_BREAKS_IN_TRANSMISSION_SEQUENCE_NUMBER, 7, inputMessage,
+                                            e));
+                });
+    }
+
+    @Test
+    public void parse_fails_when_standard_message_does_not_end_with_expected_end_signals() {
+        messageFormatsContaining(MessageFormat.STANDARD)//
+                .forEach(acceptedFormats -> {
+                    final String inputMessage = "\u0001\r\r\n" //
+                            + "013" + "\r\r\n"//
+                            + "FTYU31 YUDO 160000" + "\r\r\n" //
+                            + "TAF YUDO 160000Z NIL=\r\r\n" //
+                            + "TAF YUDD 160000Z NIL=" + "\r\n\u0003";
+                    assertThatExceptionOfType(GTSMeteorologicalMessageParseException.class)//
+                            .isThrownBy(() -> builder().parse(inputMessage))//
+                            .satisfies(e -> assertGTSExchangeFileParseException(ErrorCode.MISSING_END_OF_MESSAGE_SIGNALS, 75, inputMessage, e));
+                });
+    }
+
+    @Test
+    public void parse_fails_when_standard_message_heading_contains_line_break_characters() {
+        messageFormatsContaining(MessageFormat.STANDARD)//
+                .forEach(acceptedFormats -> {
+                    final Stream<String> inputMessages = Stream.of(//
+                                    stringOf(CARRIAGE_RETURN), //
+                                    stringOf(LINE_FEED), //
+                                    stringOf(CARRIAGE_RETURN, LINE_FEED), //
+                                    stringOf(LINE_FEED, CARRIAGE_RETURN), //
+                                    stringOf(LINE_FEED, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, LINE_FEED))// Contains no CR+CR+LF sequence
+                            .map(separator -> "\u0001\r\r\n" //
+                                    + "013" + "\r\r\n"//
+                                    + "FTYU31 YUDO 160000" + separator //
+                                    + "TAF YUDO 160000Z NIL=" + "\r\r\n" //
+                                    + "TAF YUDD 160000Z NIL=" + "\r\r\n\u0003");
+                    assertThat(inputMessages)//
+                            .allSatisfy(inputMessage -> assertThatExceptionOfType(GTSMeteorologicalMessageParseException.class)//
+                                    .isThrownBy(() -> builder().parse(inputMessage, acceptedFormats))//
+                                    .satisfies(e -> assertGTSExchangeFileParseException(ErrorCode.UNEXPECTED_LINE_BREAKS_IN_HEADING, 28, inputMessage, e)));
+                });
+    }
+
+    @Test
+    public void parse_fails_when_short_message_heading_contains_line_break_characters() {
+        messageFormatsContaining(MessageFormat.SHORT)//
+                .forEach(acceptedFormats -> {
+                    final Stream<String> inputMessages = Stream.of(//
+                                    stringOf(CARRIAGE_RETURN), //
+                                    stringOf(LINE_FEED), //
+                                    stringOf(CARRIAGE_RETURN, LINE_FEED), //
+                                    stringOf(LINE_FEED, CARRIAGE_RETURN), //
+                                    stringOf(LINE_FEED, CARRIAGE_RETURN, LINE_FEED, LINE_FEED, CARRIAGE_RETURN, LINE_FEED))// Contains no CR+CR+LF sequence
+                            .map(separator -> "\r\r\n"//
+                                    + "FTYU31 YUDO 160000" + separator //
+                                    + "TAF YUDO 160000Z NIL=" + "\r\r\n" //
+                                    + "TAF YUDD 160000Z NIL=");
+                    assertThat(inputMessages)//
+                            .allSatisfy(inputMessage -> assertThatExceptionOfType(GTSMeteorologicalMessageParseException.class)//
+                                    .isThrownBy(() -> builder().parse(inputMessage, acceptedFormats))//
+                                    .satisfies(e -> assertGTSExchangeFileParseException(ErrorCode.UNEXPECTED_LINE_BREAKS_IN_HEADING, 21, inputMessage, e)));
+                });
+    }
+
+    @Test
+    public void parse_fails_on_short_message_when_heading_is_not_preceded_by_expected_prefix() {
+        messageFormatsContaining(MessageFormat.SHORT)//
+                .forEach(acceptedFormats -> {
+                    final String inputMessage = "\r\r" //
+                            + "FTYU31 YUDO 160000" + "\r\r\n" //
+                            + "TAF YUDO 160000Z NIL=\r\r\n" //
+                            + "TAF YUDD 160000Z NIL=";
+                    final ErrorCode expectedErrorCode;
+                    if (acceptedFormats.contains(MessageFormat.HEADING_AND_TEXT)) {
+                        expectedErrorCode = ErrorCode.UNEXPECTED_LINE_BREAKS_IN_HEADING;
+                    } else if (acceptedFormats.contains(MessageFormat.STANDARD)) {
+                        expectedErrorCode = ErrorCode.MISSING_STARTING_LINE_PREFIX;
+                    } else {
+                        expectedErrorCode = ErrorCode.MISSING_HEADING_PREFIX;
+                    }
+                    assertThatExceptionOfType(GTSMeteorologicalMessageParseException.class)//
+                            .isThrownBy(() -> builder().parse(inputMessage, acceptedFormats))//
+                            .satisfies(e -> assertGTSExchangeFileParseException(expectedErrorCode, 0, inputMessage, e));
+                });
+    }
+
+    @Test
+    public void parse_fails_on_short_message_when_heading_and_text_separator_not_found() {
+        messageFormatsContaining(MessageFormat.SHORT)//
+                .forEach(acceptedFormats -> {
+                    final String inputMessage = "\r\r\n"//
+                            + "FTYU31 YUDO 160000 " //
+                            + "TAF YUDD 160000Z NIL=";
+                    assertThatExceptionOfType(GTSMeteorologicalMessageParseException.class)//
+                            .isThrownBy(() -> builder().parse(inputMessage, acceptedFormats))//
+                            .satisfies(e -> assertGTSExchangeFileParseException(ErrorCode.NO_SEPARATION_OF_HEADING_AND_TEXT, 3, inputMessage, e));
+                });
+    }
+
+    @Test
+    public void parse_fails_on_short_message_when_actual_content_is_smaller_than_given_message_length() {
+        messageFormatsContaining(MessageFormat.SHORT)//
+                .forEach(acceptedFormats -> {
+                    final String inputMessage = "\r\r\n"//
+                            + "FTYU31 YUDO 160000" + "\r\r\n" //
+                            + "TAF YUDO 160000Z NIL=" + "\r\r\n" //
+                            + "TAF YUDD 160000Z NIL=";
+                    assertThatExceptionOfType(GTSMeteorologicalMessageParseException.class)//
+                            .isThrownBy(() -> builder().parse(inputMessage, 0, 100, acceptedFormats))//
+                            .satisfies(e -> assertGTSExchangeFileParseException(ErrorCode.UNEXPECTED_END_OF_TEXT, 24, inputMessage, e));
+                });
+    }
+
+    @Test
+    public void transmissionSequenceNumber_is_empty_by_default() {
+        final GTSMeteorologicalMessage.Builder builder = GTSMeteorologicalMessage.builder();
+        assertThat(builder.getTransmissionSequenceNumber()).isEmpty();
+    }
+
+    @Test
+    public void clearTransmissionSequenceNumber_sets_value_to_empty_string() {
+        final GTSMeteorologicalMessage.Builder builder = builder()//
+                .setTransmissionSequenceNumber("123");
+        assertThat(builder.getTransmissionSequenceNumber()).isEqualTo("123");
+        builder.clearTransmissionSequenceNumber();
+        assertThat(builder.getTransmissionSequenceNumber()).isEmpty();
+    }
+
+    @Test
+    public void getTransmissionSequenceNumberAsInt_returns_empty_when_getTransmissionSequenceNumber_is_empty() {
+        final GTSMeteorologicalMessage.Builder builder = builder()//
+                .clearTransmissionSequenceNumber();
+        final GTSMeteorologicalMessage value = builder.buildPartial();
+        assertThat(builder.getTransmissionSequenceNumber()).as("builder.getTransmissionSequenceNumber()").isEmpty();
+        assertThat(builder.getTransmissionSequenceNumberAsInt()).as("builder.getTransmissionSequenceNumberAsInt()").isEmpty();
+        assertThat(value.getTransmissionSequenceNumberAsInt()).as("value.getTransmissionSequenceNumberAsInt()").isEmpty();
+    }
+
+    @Test
+    public void getTransmissionSequenceNumberAsInt_returns_empty_when_getTransmissionSequenceNumber_is_text() {
+        final GTSMeteorologicalMessage.Builder builder = builder()//
+                .setTransmissionSequenceNumber("ABC");
+        final GTSMeteorologicalMessage value = builder.buildPartial();
+        assertThat(builder.getTransmissionSequenceNumber()).as("builder.getTransmissionSequenceNumber()").isEqualTo("ABC");
+        assertThat(builder.getTransmissionSequenceNumberAsInt()).as("builder.getTransmissionSequenceNumberAsInt()").isEmpty();
+        assertThat(value.getTransmissionSequenceNumberAsInt()).as("value.getTransmissionSequenceNumberAsInt()").isEmpty();
+    }
+
+    @Test
+    public void getTransmissionSequenceNumberAsInt_returns_int_when_getTransmissionSequenceNumber_is_numeric() {
+        final GTSMeteorologicalMessage.Builder builder = builder()//
+                .setTransmissionSequenceNumber("00073");
+        final GTSMeteorologicalMessage value = builder.buildPartial();
+        assertThat(builder.getTransmissionSequenceNumber()).as("builder.getTransmissionSequenceNumber()").isEqualTo("00073");
+        assertThat(builder.getTransmissionSequenceNumberAsInt()).as("builder.getTransmissionSequenceNumberAsInt()").hasValue(73);
+        assertThat(value.getTransmissionSequenceNumberAsInt()).as("value.getTransmissionSequenceNumberAsInt()").hasValue(73);
+    }
+
+    @Test
+    public void setTransmissionSequenceNumberAsInt_sets_value_with_three_digits() {
+        final GTSMeteorologicalMessage.Builder builder = builder()//
+                .setTransmissionSequenceNumberAsInt(32);
+        final GTSMeteorologicalMessage value = builder.buildPartial();
+        assertThat(builder.getTransmissionSequenceNumberAsInt()).as("builder.getTransmissionSequenceNumberAsInt()").hasValue(32);
+        assertThat(builder.getTransmissionSequenceNumber()).as("builder.getTransmissionSequenceNumber()").isEqualTo("032");
+        assertThat(value.getTransmissionSequenceNumberAsInt()).as("value.getTransmissionSequenceNumberAsInt()").hasValue(32);
+        assertThat(value.getTransmissionSequenceNumber()).as("value.getTransmissionSequenceNumber()").isEqualTo("032");
+    }
+
+    @Test
+    public void getLength_given_STANDARD_returns_standard_format_length() {
+        assertThat(MESSAGE_STANDARD.getLength(MessageFormat.STANDARD)).isEqualTo(MESSAGE_STANDARD_LENGTH);
+    }
+
+    @Test
+    public void getLength_given_STANDARD_on_message_without_sequence_number_fails() {
+        assertThatIllegalArgumentException()//
+                .isThrownBy(() -> MESSAGE_SHORT.getLength(MessageFormat.STANDARD))//
+                .withMessageContaining(MessageFormat.STANDARD.name());
+    }
+
+    @Test
+    public void getLength_given_SHORT_returns_short_format_length() {
+        assertThat(MESSAGE_STANDARD.getLength(MessageFormat.SHORT)).isEqualTo(MESSAGE_SHORT_LENGTH);
+    }
+
+    @Test
+    public void getLength_given_HEADING_AND_TEXT_returns_length_of_heading_and_text() {
+        assertThat(MESSAGE_STANDARD.getLength(MessageFormat.HEADING_AND_TEXT)).isEqualTo(MESSAGE_HEADING_AND_TEXT.length());
+    }
+
+    @Test
+    public void supports_given_STANDARD_returns_true_when_sequence_number_exists() {
+        assertThat(MESSAGE_STANDARD.supports(MessageFormat.STANDARD)).isTrue();
+    }
+
+    @Test
+    public void supports_given_STANDARD_returns_false_when_sequence_number_is_missing() {
+        assertThat(MESSAGE_SHORT.supports(MessageFormat.STANDARD)).isFalse();
+    }
+
+    @Test
+    public void supports_given_SHORT_returns_always_true() {
+        Stream.of(MESSAGE_STANDARD, MESSAGE_SHORT)//
+                .forEach(message -> assertThat(message.supports(MessageFormat.SHORT)).isTrue());
+    }
+
+    @Test
+    public void supports_given_HEADING_AND_TEXT_returns_always_true() {
+        Stream.of(MESSAGE_STANDARD, MESSAGE_SHORT)//
+                .forEach(message -> assertThat(message.supports(MessageFormat.HEADING_AND_TEXT)).isTrue());
+    }
+
+    @Test
+    public void toString_returns_string_equal_to_original_standard_message() {
+        final GTSMeteorologicalMessage message = GTSMeteorologicalMessage.parse(MESSAGE_STANDARD_STRING);
+        assertThat(message.toString()).isEqualTo(MESSAGE_STANDARD_STRING);
+    }
+
+    @Test
+    public void toString_returns_string_equal_to_original_short_message() {
+        final GTSMeteorologicalMessage message = GTSMeteorologicalMessage.parse(MESSAGE_SHORT_STRING);
+        assertThat(message.toString()).isEqualTo(MESSAGE_SHORT_STRING);
+    }
+
+    @Test
+    public void toString_STANDARD_returns_string_equal_to_standard_message() {
+        final GTSMeteorologicalMessage message = GTSMeteorologicalMessage.parse(MESSAGE_STANDARD_STRING);
+        assertThat(message.toString(MessageFormat.STANDARD)).isEqualTo(MESSAGE_STANDARD_STRING);
+    }
+
+    @Test
+    public void toString_STANDARD_fails_without_transmissionSequenceNumber() {
+        final GTSMeteorologicalMessage message = GTSMeteorologicalMessage.parse(MESSAGE_SHORT_STRING);
+        assertThatIllegalArgumentException()//
+                .isThrownBy(() -> message.toString(MessageFormat.STANDARD))//
+                .withMessageContaining(MessageFormat.STANDARD.name());
+    }
+
+    @Test
+    public void toString_SHORT_returns_string_equal_to_short_message() {
+        final GTSMeteorologicalMessage message = GTSMeteorologicalMessage.parse(MESSAGE_STANDARD_STRING);
+        assertThat(message.toString(MessageFormat.SHORT)).isEqualTo(MESSAGE_SHORT_STRING);
+    }
+
+    @Test
+    public void toString_HEADING_AND_TEXT_returns_string_equal_to_heading_and_text() {
+        final GTSMeteorologicalMessage message = GTSMeteorologicalMessage.parse(MESSAGE_STANDARD_STRING);
+        assertThat(message.toString(MessageFormat.HEADING_AND_TEXT)).isEqualTo(MESSAGE_HEADING_AND_TEXT);
+    }
+}


### PR DESCRIPTION
Derive `GTSMeteorologicalMessage` and `GTSDataExchangeTranscoder` from `GTSExchangeFileTemplate`, deprecating the last.

Closes #101